### PR TITLE
Request level latency tracking

### DIFF
--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -182,6 +182,9 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         this.indexRoutings = indexRoutings;
         this.results = resultConsumer;
         this.clusters = clusters;
+        if (timeProvider.isPhaseTookEnabled()) {
+            searchListenersList.add(timeProvider);
+        }
         if (!CollectionUtils.isEmpty(searchListenersList)) {
             this.searchListenersList = searchListenersList;
             this.searchRequestOperationsListener = new SearchRequestOperationsListener.CompositeListener(this.searchListenersList, logger);
@@ -333,6 +336,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
                     0,
                     0,
                     buildTookInMillis(),
+                    timeProvider.getPhaseTook(),
                     ShardSearchFailure.EMPTY_ARRAY,
                     clusters,
                     null
@@ -791,6 +795,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
             successfulOps.get(),
             skippedOps.get(),
             buildTookInMillis(),
+            timeProvider.getPhaseTook(),
             failures,
             clusters,
             searchContextId

--- a/server/src/main/java/org/opensearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequest.java
@@ -117,6 +117,8 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
 
     private String pipeline;
 
+    private Boolean phaseTookQueryParamEnabled = null;
+
     public SearchRequest() {
         this.localClusterAlias = null;
         this.absoluteStartMillis = DEFAULT_ABSOLUTE_START_MILLIS;
@@ -209,6 +211,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         this.absoluteStartMillis = absoluteStartMillis;
         this.finalReduce = finalReduce;
         this.cancelAfterTimeInterval = searchRequest.cancelAfterTimeInterval;
+        this.phaseTookQueryParamEnabled = searchRequest.phaseTookQueryParamEnabled;
     }
 
     /**
@@ -253,6 +256,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         if (in.getVersion().onOrAfter(Version.V_2_7_0)) {
             pipeline = in.readOptionalString();
         }
+        phaseTookQueryParamEnabled = in.readOptionalBoolean();
     }
 
     @Override
@@ -284,6 +288,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         if (out.getVersion().onOrAfter(Version.V_2_7_0)) {
             out.writeOptionalString(pipeline);
         }
+        out.writeOptionalBoolean(phaseTookQueryParamEnabled);
     }
 
     @Override
@@ -615,6 +620,33 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         this.preFilterShardSize = preFilterShardSize;
     }
 
+    enum ParamValue {
+        TRUE,
+        FALSE,
+        UNSET
+    }
+
+    /**
+     * Returns value of user-provided phase_took query parameter for this search request.
+     * Defaults to <code>false</code>.
+     */
+    public ParamValue isPhaseTookQueryParamEnabled() {
+        if (phaseTookQueryParamEnabled == null) {
+            return ParamValue.UNSET;
+        } else if (phaseTookQueryParamEnabled == true) {
+            return ParamValue.TRUE;
+        } else {
+            return ParamValue.FALSE;
+        }
+    }
+
+    /**
+     * Sets value of phase_took query param if provided by user. Defaults to <code>null</code>.
+     */
+    public void setPhaseTookQueryParamEnabled(boolean phaseTookQueryParamEnabled) {
+        this.phaseTookQueryParamEnabled = phaseTookQueryParamEnabled;
+    }
+
     /**
      * Returns a threshold that enforces a pre-filter roundtrip to pre-filter search shards based on query rewriting if the number of shards
      * the search request expands to exceeds the threshold, or <code>null</code> if the threshold is unspecified.
@@ -719,7 +751,8 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             && absoluteStartMillis == that.absoluteStartMillis
             && ccsMinimizeRoundtrips == that.ccsMinimizeRoundtrips
             && Objects.equals(cancelAfterTimeInterval, that.cancelAfterTimeInterval)
-            && Objects.equals(pipeline, that.pipeline);
+            && Objects.equals(pipeline, that.pipeline)
+            && Objects.equals(phaseTookQueryParamEnabled, that.phaseTookQueryParamEnabled);
     }
 
     @Override
@@ -740,7 +773,8 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             localClusterAlias,
             absoluteStartMillis,
             ccsMinimizeRoundtrips,
-            cancelAfterTimeInterval
+            cancelAfterTimeInterval,
+            phaseTookQueryParamEnabled
         );
     }
 
@@ -783,6 +817,8 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             + cancelAfterTimeInterval
             + ", pipeline="
             + pipeline
+            + ", phaseTookQueryParamEnabled="
+            + phaseTookQueryParamEnabled
             + "}";
     }
 }

--- a/server/src/main/java/org/opensearch/action/search/SearchResponseMerger.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchResponseMerger.java
@@ -236,6 +236,7 @@ final class SearchResponseMerger {
             successfulShards,
             skippedShards,
             tookInMillis,
+            searchTimeProvider.getPhaseTook(),
             shardFailures,
             clusters,
             null

--- a/server/src/main/java/org/opensearch/action/search/SearchScrollAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchScrollAsyncAction.java
@@ -299,6 +299,7 @@ abstract class SearchScrollAsyncAction<T extends SearchPhaseResult> implements R
                     successfulOps.get(),
                     0,
                     buildTookInMillis(),
+                    SearchResponse.PhaseTook.NULL,
                     buildShardFailures(),
                     SearchResponse.Clusters.EMPTY,
                     null

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -57,6 +57,7 @@ import org.opensearch.cluster.routing.ShardIterator;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.unit.TimeValue;
@@ -109,6 +110,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
@@ -148,6 +150,14 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     public static final String SEARCH_REQUEST_STATS_ENABLED_KEY = "search.request_stats_enabled";
     public static final Setting<Boolean> SEARCH_REQUEST_STATS_ENABLED = Setting.boolSetting(
         SEARCH_REQUEST_STATS_ENABLED_KEY,
+        false,
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
+    public static final String SEARCH_PHASE_TOOK_ENABLED_KEY = "search.phase_took_enabled";
+    public static final Setting<Boolean> SEARCH_PHASE_TOOK_ENABLED = Setting.boolSetting(
+        SEARCH_PHASE_TOOK_ENABLED_KEY,
         false,
         Property.Dynamic,
         Property.NodeScope
@@ -260,11 +270,12 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
      *
      * @opensearch.internal
      */
-    static final class SearchTimeProvider {
+    static final class SearchTimeProvider implements SearchRequestOperationsListener {
 
         private final long absoluteStartMillis;
         private final long relativeStartNanos;
         private final LongSupplier relativeCurrentNanosProvider;
+        private boolean phaseTookEnabled = false;
 
         /**
          * Instantiates a new search time provider. The absolute start time is the real clock time
@@ -290,6 +301,118 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         long buildTookInMillis() {
             return TimeUnit.NANOSECONDS.toMillis(relativeCurrentNanosProvider.getAsLong() - relativeStartNanos);
         }
+
+        public void setPhaseTookEnabled(boolean phaseTookEnabled) {
+            this.phaseTookEnabled = phaseTookEnabled;
+        }
+
+        public boolean isPhaseTookEnabled() {
+            return phaseTookEnabled;
+        }
+
+        SearchResponse.PhaseTook getPhaseTook() {
+            if (phaseTookEnabled) {
+                return new SearchResponse.PhaseTook(
+                    totalStats.dfsPreQueryTotal.count(),
+                    totalStats.canMatchTotal.count(),
+                    totalStats.queryTotal.count(),
+                    totalStats.fetchTotal.count(),
+                    totalStats.expandSearchTotal.count()
+                );
+            } else {
+                return SearchResponse.PhaseTook.NULL;
+            }
+        }
+
+        public SearchTimeProvider.RequestStatsHolder totalStats = new RequestStatsHolder();
+
+        public static final class RequestStatsHolder {
+            public CounterMetric dfsPreQueryTotal = new CounterMetric();
+            public CounterMetric canMatchTotal = new CounterMetric();
+            public CounterMetric queryTotal = new CounterMetric();
+            public CounterMetric fetchTotal = new CounterMetric();
+            public CounterMetric expandSearchTotal = new CounterMetric();
+        }
+
+        // call these to populate return values
+        public long getDFSPreQueryTotal() {
+            return totalStats.dfsPreQueryTotal.count();
+        }
+
+        public long getCanMatchTotal() {
+            return totalStats.canMatchTotal.count();
+        }
+
+        public long getQueryTotal() {
+            return totalStats.queryTotal.count();
+        }
+
+        public long getFetchTotal() {
+            return totalStats.fetchTotal.count();
+        }
+
+        public long getExpandSearchTotal() {
+            return totalStats.expandSearchTotal.count();
+        }
+
+        private void computeStats(Consumer<SearchTimeProvider.RequestStatsHolder> consumer) {
+            consumer.accept(totalStats);
+        }
+
+        @Override
+        public void onDFSPreQueryPhaseStart(SearchPhaseContext context) {}
+
+        @Override
+        public void onDFSPreQueryPhaseEnd(SearchPhaseContext context, long tookTime) {
+            computeStats(statsHolder -> { totalStats.dfsPreQueryTotal.inc(tookTime); });
+        }
+
+        @Override
+        public void onDFSPreQueryPhaseFailure(SearchPhaseContext context) {}
+
+        @Override
+        public void onCanMatchPhaseStart(SearchPhaseContext context) {}
+
+        @Override
+        public void onCanMatchPhaseEnd(SearchPhaseContext context, long tookTime) {
+            computeStats(statsHolder -> { totalStats.canMatchTotal.inc(tookTime); });
+        }
+
+        @Override
+        public void onCanMatchPhaseFailure(SearchPhaseContext context) {}
+
+        @Override
+        public void onQueryPhaseStart(SearchPhaseContext context) {}
+
+        @Override
+        public void onQueryPhaseEnd(SearchPhaseContext context, long tookTime) {
+            computeStats(statsHolder -> { totalStats.queryTotal.inc(tookTime); });
+        }
+
+        @Override
+        public void onQueryPhaseFailure(SearchPhaseContext context) {}
+
+        @Override
+        public void onFetchPhaseStart(SearchPhaseContext context) {}
+
+        @Override
+        public void onFetchPhaseEnd(SearchPhaseContext context, long tookTime) {
+            computeStats(statsHolder -> { totalStats.fetchTotal.inc(tookTime); });
+        }
+
+        @Override
+        public void onFetchPhaseFailure(SearchPhaseContext context) {}
+
+        @Override
+        public void onExpandSearchPhaseStart(SearchPhaseContext context) {}
+
+        @Override
+        public void onExpandSearchPhaseEnd(SearchPhaseContext context, long tookTime) {
+            computeStats(statsHolder -> { totalStats.expandSearchTotal.inc(tookTime); });
+        }
+
+        @Override
+        public void onExpandSearchPhaseFailure(SearchPhaseContext context) {}
     }
 
     @Override
@@ -350,6 +473,12 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 ThreadPool threadPool,
                 SearchResponse.Clusters clusters
             ) {
+                if (searchRequest.isPhaseTookQueryParamEnabled() == SearchRequest.ParamValue.TRUE
+                    || (searchRequest.isPhaseTookQueryParamEnabled() == SearchRequest.ParamValue.UNSET
+                        && clusterService.getClusterSettings().get(TransportSearchAction.SEARCH_PHASE_TOOK_ENABLED))) {
+                    timeProvider.setPhaseTookEnabled(true);
+                }
+
                 return new AbstractSearchAsyncAction<SearchPhaseResult>(
                     actionName,
                     logger,
@@ -412,6 +541,11 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             relativeStartNanos,
             System::nanoTime
         );
+        if (originalSearchRequest.isPhaseTookQueryParamEnabled() == SearchRequest.ParamValue.TRUE
+            || (originalSearchRequest.isPhaseTookQueryParamEnabled() == SearchRequest.ParamValue.UNSET
+                && clusterService.getClusterSettings().get(TransportSearchAction.SEARCH_PHASE_TOOK_ENABLED))) {
+            timeProvider.setPhaseTookEnabled(true);
+        }
         PipelinedRequest searchRequest;
         ActionListener<SearchResponse> listener;
         try {
@@ -615,6 +749,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                             searchResponse.getSuccessfulShards(),
                             searchResponse.getSkippedShards(),
                             timeProvider.buildTookInMillis(),
+                            timeProvider.getPhaseTook(),
                             searchResponse.getShardFailures(),
                             new SearchResponse.Clusters(1, 1, 0),
                             searchResponse.pointInTimeId()

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -374,6 +374,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 TransportSearchAction.SHARD_COUNT_LIMIT_SETTING,
                 TransportSearchAction.SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING,
                 TransportSearchAction.SEARCH_REQUEST_STATS_ENABLED,
+                TransportSearchAction.SEARCH_PHASE_TOOK_ENABLED,
                 RemoteClusterService.REMOTE_CLUSTER_SKIP_UNAVAILABLE,
                 SniffConnectionStrategy.REMOTE_CONNECTIONS_PER_CLUSTER,
                 RemoteClusterService.REMOTE_INITIAL_CONNECTION_TIMEOUT_SETTING,

--- a/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/search/RestSearchAction.java
@@ -180,6 +180,12 @@ public class RestSearchAction extends BaseRestHandler {
             searchRequest.allowPartialSearchResults(request.paramAsBoolean("allow_partial_search_results", null));
         }
 
+        if (request.hasParam("phase_took")) {
+            // only set if we have the parameter passed to override the cluster-level default
+            // else phaseTookQueryParamEnabled = null
+            searchRequest.setPhaseTookQueryParamEnabled(request.paramAsBoolean("phase_took", true));
+        }
+
         // do not allow 'query_and_fetch' or 'dfs_query_and_fetch' search types
         // from the REST layer. these modes are an internal optimization and should
         // not be specified explicitly by the user.

--- a/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
@@ -680,7 +680,11 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
         );
         AtomicReference<Exception> exception = new AtomicReference<>();
         ActionListener<SearchResponse> listener = ActionListener.wrap(response -> fail("onResponse should not be called"), exception::set);
-
+        TransportSearchAction.SearchTimeProvider timeProvider = new TransportSearchAction.SearchTimeProvider(
+            0,
+            System.nanoTime(),
+            System::nanoTime
+        );
         return new SearchDfsQueryThenFetchAsyncAction(
             logger,
             null,
@@ -694,7 +698,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             searchRequest,
             listener,
             shardsIter,
-            null,
+            timeProvider,
             null,
             task,
             SearchResponse.Clusters.EMPTY,
@@ -726,6 +730,11 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
         );
         AtomicReference<Exception> exception = new AtomicReference<>();
         ActionListener<SearchResponse> listener = ActionListener.wrap(response -> fail("onResponse should not be called"), exception::set);
+        TransportSearchAction.SearchTimeProvider timeProvider = new TransportSearchAction.SearchTimeProvider(
+            0,
+            System.nanoTime(),
+            System::nanoTime
+        );
         return new SearchQueryThenFetchAsyncAction(
             logger,
             null,
@@ -739,7 +748,7 @@ public class AbstractSearchAsyncActionTests extends OpenSearchTestCase {
             searchRequest,
             listener,
             shardsIter,
-            null,
+            timeProvider,
             null,
             task,
             SearchResponse.Clusters.EMPTY,

--- a/server/src/test/java/org/opensearch/action/search/CreatePitControllerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/CreatePitControllerTests.java
@@ -133,6 +133,7 @@ public class CreatePitControllerTests extends OpenSearchTestCase {
             3,
             0,
             100,
+            SearchResponse.PhaseTook.NULL,
             ShardSearchFailure.EMPTY_ARRAY,
             SearchResponse.Clusters.EMPTY,
             pitId

--- a/server/src/test/java/org/opensearch/action/search/MockSearchPhaseContext.java
+++ b/server/src/test/java/org/opensearch/action/search/MockSearchPhaseContext.java
@@ -118,6 +118,7 @@ public final class MockSearchPhaseContext implements SearchPhaseContext {
                 numSuccess.get(),
                 0,
                 0,
+                SearchResponse.PhaseTook.NULL,
                 failures.toArray(ShardSearchFailure.EMPTY_ARRAY),
                 SearchResponse.Clusters.EMPTY,
                 searchContextId

--- a/server/src/test/java/org/opensearch/action/search/MultiSearchResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/MultiSearchResponseTests.java
@@ -68,6 +68,7 @@ public class MultiSearchResponseTests extends AbstractXContentTestCase<MultiSear
                 successfulShards,
                 skippedShards,
                 tookInMillis,
+                SearchResponse.PhaseTook.NULL,
                 ShardSearchFailure.EMPTY_ARRAY,
                 clusters,
                 null
@@ -96,6 +97,7 @@ public class MultiSearchResponseTests extends AbstractXContentTestCase<MultiSear
                     successfulShards,
                     skippedShards,
                     tookInMillis,
+                    SearchResponse.PhaseTook.NULL,
                     ShardSearchFailure.EMPTY_ARRAY,
                     clusters,
                     null

--- a/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchAsyncActionTests.java
@@ -713,7 +713,7 @@ public class SearchAsyncActionTests extends OpenSearchTestCase {
         final Set<ShardId> queried = new HashSet<>();
 
         TestSearchResponse() {
-            super(InternalSearchResponse.empty(), null, 0, 0, 0, 0L, ShardSearchFailure.EMPTY_ARRAY, Clusters.EMPTY, null);
+            super(InternalSearchResponse.empty(), null, 0, 0, 0, 0L, PhaseTook.NULL, ShardSearchFailure.EMPTY_ARRAY, Clusters.EMPTY, null);
         }
     }
 

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestTests.java
@@ -107,6 +107,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         Version version = VersionUtils.randomVersion(random());
         SearchRequest deserializedRequest = copyWriteable(searchRequest, namedWriteableRegistry, SearchRequest::new, version);
         assertEquals(searchRequest.isCcsMinimizeRoundtrips(), deserializedRequest.isCcsMinimizeRoundtrips());
+        assertEquals(searchRequest.isPhaseTookQueryParamEnabled(), deserializedRequest.isPhaseTookQueryParamEnabled());
         assertEquals(searchRequest.getLocalClusterAlias(), deserializedRequest.getLocalClusterAlias());
         assertEquals(searchRequest.getAbsoluteStartMillis(), deserializedRequest.getAbsoluteStartMillis());
         assertEquals(searchRequest.isFinalReduce(), deserializedRequest.isFinalReduce());
@@ -244,6 +245,9 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         );
         mutators.add(() -> mutation.source(randomValueOtherThan(searchRequest.source(), this::createSearchSourceBuilder)));
         mutators.add(() -> mutation.setCcsMinimizeRoundtrips(searchRequest.isCcsMinimizeRoundtrips() == false));
+        mutators.add(
+            () -> mutation.setPhaseTookQueryParamEnabled(searchRequest.isPhaseTookQueryParamEnabled() == SearchRequest.ParamValue.FALSE)
+        );
         mutators.add(
             () -> mutation.setCancelAfterTimeInterval(
                 searchRequest.getCancelAfterTimeInterval() != null

--- a/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchResponseTests.java
@@ -152,6 +152,13 @@ public class SearchResponseTests extends OpenSearchTestCase {
         Boolean terminatedEarly = randomBoolean() ? null : randomBoolean();
         int numReducePhases = randomIntBetween(1, 10);
         long tookInMillis = randomNonNegativeLong();
+        SearchResponse.PhaseTook phaseTook = new SearchResponse.PhaseTook(
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomNonNegativeLong()
+        );
         int totalShards = randomIntBetween(1, Integer.MAX_VALUE);
         int successfulShards = randomIntBetween(0, totalShards);
         int skippedShards = randomIntBetween(0, totalShards);
@@ -182,6 +189,7 @@ public class SearchResponseTests extends OpenSearchTestCase {
             successfulShards,
             skippedShards,
             tookInMillis,
+            phaseTook,
             shardSearchFailures,
             randomBoolean() ? randomClusters() : SearchResponse.Clusters.EMPTY,
             null
@@ -320,6 +328,7 @@ public class SearchResponseTests extends OpenSearchTestCase {
                 0,
                 0,
                 0,
+                SearchResponse.PhaseTook.NULL,
                 ShardSearchFailure.EMPTY_ARRAY,
                 SearchResponse.Clusters.EMPTY,
                 null
@@ -368,13 +377,23 @@ public class SearchResponseTests extends OpenSearchTestCase {
                 0,
                 0,
                 0,
+                new SearchResponse.PhaseTook(0, 0, 50, 25, 0),
                 ShardSearchFailure.EMPTY_ARRAY,
-                new SearchResponse.Clusters(5, 3, 2)
+                new SearchResponse.Clusters(5, 3, 2),
+                null
             );
             StringBuilder expectedString = new StringBuilder();
             expectedString.append("{");
             {
                 expectedString.append("\"took\":0,");
+                expectedString.append("\"phase_took\":");
+                {
+                    expectedString.append("{\"dfs_prequery\":0,");
+                    expectedString.append("\"can_match\":0,");
+                    expectedString.append("\"query\":50,");
+                    expectedString.append("\"fetch\":25,");
+                    expectedString.append("\"expand_search\":0},");
+                }
                 expectedString.append("\"timed_out\":false,");
                 expectedString.append("\"_shards\":");
                 {

--- a/server/src/test/java/org/opensearch/action/search/SearchTimeProviderTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchTimeProviderTests.java
@@ -1,0 +1,175 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.search;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Phaser;
+
+public class SearchTimeProviderTests extends OpenSearchTestCase {
+    public void testSearchRequestPhaseFailure() {
+        TransportSearchAction.SearchTimeProvider testRequestStats = new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0);
+        SearchPhaseContext ctx = new MockSearchPhaseContext(1);
+
+        testRequestStats.onDFSPreQueryPhaseStart(ctx);
+        testRequestStats.onDFSPreQueryPhaseFailure(ctx);
+        assertEquals(0, testRequestStats.getDFSPreQueryTotal());
+
+        testRequestStats.onCanMatchPhaseStart(ctx);
+        testRequestStats.onCanMatchPhaseFailure(ctx);
+        assertEquals(0, testRequestStats.getCanMatchTotal());
+
+        testRequestStats.onQueryPhaseStart(ctx);
+        testRequestStats.onQueryPhaseFailure(ctx);
+        assertEquals(0, testRequestStats.getQueryTotal());
+
+        testRequestStats.onFetchPhaseStart(ctx);
+        testRequestStats.onFetchPhaseFailure(ctx);
+        assertEquals(0, testRequestStats.getFetchTotal());
+
+        testRequestStats.onExpandSearchPhaseStart(ctx);
+        testRequestStats.onExpandSearchPhaseFailure(ctx);
+        assertEquals(0, testRequestStats.getExpandSearchTotal());
+    }
+
+    public void testSearchTimeProvider() {
+        TransportSearchAction.SearchTimeProvider testRequestStats = new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0);
+
+        SearchPhaseContext ctx = new MockSearchPhaseContext(1);
+        long tookTime = randomIntBetween(1, 10);
+
+        testRequestStats.onDFSPreQueryPhaseStart(ctx);
+        testRequestStats.onDFSPreQueryPhaseEnd(ctx, tookTime);
+        assertEquals(tookTime, testRequestStats.getDFSPreQueryTotal());
+
+        testRequestStats.onCanMatchPhaseStart(ctx);
+        testRequestStats.onCanMatchPhaseEnd(ctx, tookTime);
+        assertEquals(tookTime, testRequestStats.getCanMatchTotal());
+
+        testRequestStats.onQueryPhaseStart(ctx);
+        testRequestStats.onQueryPhaseEnd(ctx, tookTime);
+        assertEquals(tookTime, testRequestStats.getQueryTotal());
+
+        testRequestStats.onFetchPhaseStart(ctx);
+        testRequestStats.onFetchPhaseEnd(ctx, tookTime);
+        testRequestStats.onFetchPhaseEnd(ctx, 10);
+        assertEquals(tookTime + 10, testRequestStats.getFetchTotal());
+
+        testRequestStats.onExpandSearchPhaseStart(ctx);
+        testRequestStats.onExpandSearchPhaseEnd(ctx, tookTime);
+        testRequestStats.onExpandSearchPhaseEnd(ctx, tookTime);
+        assertEquals(2 * tookTime, testRequestStats.getExpandSearchTotal());
+    }
+
+    public void testSearchTimeProviderOnDFSPreQueryEndConcurrently() throws InterruptedException {
+        TransportSearchAction.SearchTimeProvider testRequestStats = new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0);
+        SearchPhaseContext ctx = new MockSearchPhaseContext(1);
+        int numTasks = randomIntBetween(5, 50);
+        long tookTime = randomIntBetween(1, 10);
+        Thread[] threads = new Thread[numTasks];
+        Phaser phaser = new Phaser(numTasks + 1);
+        CountDownLatch countDownLatch = new CountDownLatch(numTasks);
+        for (int i = 0; i < numTasks; i++) {
+            threads[i] = new Thread(() -> {
+                phaser.arriveAndAwaitAdvance();
+                testRequestStats.onDFSPreQueryPhaseEnd(ctx, tookTime);
+                countDownLatch.countDown();
+            });
+            threads[i].start();
+        }
+        phaser.arriveAndAwaitAdvance();
+        countDownLatch.await();
+        assertEquals(tookTime * numTasks, testRequestStats.getDFSPreQueryTotal());
+    }
+
+    public void testSearchTimeProviderOnCanMatchQueryEndConcurrently() throws InterruptedException {
+        TransportSearchAction.SearchTimeProvider testRequestStats = new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0);
+        SearchPhaseContext ctx = new MockSearchPhaseContext(1);
+        int numTasks = randomIntBetween(5, 50);
+        long tookTime = randomIntBetween(1, 10);
+        Thread[] threads = new Thread[numTasks];
+        Phaser phaser = new Phaser(numTasks + 1);
+        CountDownLatch countDownLatch = new CountDownLatch(numTasks);
+        for (int i = 0; i < numTasks; i++) {
+            threads[i] = new Thread(() -> {
+                phaser.arriveAndAwaitAdvance();
+                testRequestStats.onCanMatchPhaseEnd(ctx, tookTime);
+                countDownLatch.countDown();
+            });
+            threads[i].start();
+        }
+        phaser.arriveAndAwaitAdvance();
+        countDownLatch.await();
+        assertEquals(tookTime * numTasks, testRequestStats.getCanMatchTotal());
+    }
+
+    public void testSearchTimeProviderOnQueryEndConcurrently() throws InterruptedException {
+        TransportSearchAction.SearchTimeProvider testRequestStats = new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0);
+        SearchPhaseContext ctx = new MockSearchPhaseContext(1);
+        int numTasks = randomIntBetween(5, 50);
+        long tookTime = randomIntBetween(1, 10);
+        Thread[] threads = new Thread[numTasks];
+        Phaser phaser = new Phaser(numTasks + 1);
+        CountDownLatch countDownLatch = new CountDownLatch(numTasks);
+        for (int i = 0; i < numTasks; i++) {
+            threads[i] = new Thread(() -> {
+                phaser.arriveAndAwaitAdvance();
+                testRequestStats.onQueryPhaseEnd(ctx, tookTime);
+                countDownLatch.countDown();
+            });
+            threads[i].start();
+        }
+        phaser.arriveAndAwaitAdvance();
+        countDownLatch.await();
+        assertEquals(tookTime * numTasks, testRequestStats.getQueryTotal());
+    }
+
+    public void testSearchTimeProviderOnFetchEndConcurrently() throws InterruptedException {
+        TransportSearchAction.SearchTimeProvider testRequestStats = new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0);
+        SearchPhaseContext ctx = new MockSearchPhaseContext(1);
+        int numTasks = randomIntBetween(5, 50);
+        long tookTime = randomIntBetween(1, 10);
+        Thread[] threads = new Thread[numTasks];
+        Phaser phaser = new Phaser(numTasks + 1);
+        CountDownLatch countDownLatch = new CountDownLatch(numTasks);
+        for (int i = 0; i < numTasks; i++) {
+            threads[i] = new Thread(() -> {
+                phaser.arriveAndAwaitAdvance();
+                testRequestStats.onFetchPhaseEnd(ctx, tookTime);
+                countDownLatch.countDown();
+            });
+            threads[i].start();
+        }
+        phaser.arriveAndAwaitAdvance();
+        countDownLatch.await();
+        assertEquals(tookTime * numTasks, testRequestStats.getFetchTotal());
+    }
+
+    public void testSearchTimeProviderOnExpandSearchEndConcurrently() throws InterruptedException {
+        TransportSearchAction.SearchTimeProvider testRequestStats = new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0);
+        SearchPhaseContext ctx = new MockSearchPhaseContext(1);
+        int numTasks = randomIntBetween(5, 50);
+        long tookTime = randomIntBetween(1, 10);
+        Thread[] threads = new Thread[numTasks];
+        Phaser phaser = new Phaser(numTasks + 1);
+        CountDownLatch countDownLatch = new CountDownLatch(numTasks);
+        for (int i = 0; i < numTasks; i++) {
+            threads[i] = new Thread(() -> {
+                phaser.arriveAndAwaitAdvance();
+                testRequestStats.onExpandSearchPhaseEnd(ctx, tookTime);
+                countDownLatch.countDown();
+            });
+            threads[i].start();
+        }
+        phaser.arriveAndAwaitAdvance();
+        countDownLatch.await();
+        assertEquals(tookTime * numTasks, testRequestStats.getExpandSearchTotal());
+    }
+}

--- a/server/src/test/java/org/opensearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/TransportSearchActionTests.java
@@ -445,7 +445,18 @@ public class TransportSearchActionTests extends OpenSearchTestCase {
             null,
             1
         );
-        return new SearchResponse(response, null, 1, 1, 0, 100, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY, null);
+        return new SearchResponse(
+            response,
+            null,
+            1,
+            1,
+            0,
+            100,
+            SearchResponse.PhaseTook.NULL,
+            ShardSearchFailure.EMPTY_ARRAY,
+            SearchResponse.Clusters.EMPTY,
+            null
+        );
     }
 
     public void testCCSRemoteReduceMergeFails() throws Exception {

--- a/server/src/test/java/org/opensearch/search/GenericSearchExtBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/GenericSearchExtBuilderTests.java
@@ -264,6 +264,7 @@ public class GenericSearchExtBuilderTests extends OpenSearchTestCase {
             successfulShards,
             skippedShards,
             tookInMillis,
+            SearchResponse.PhaseTook.NULL,
             shardSearchFailures,
             randomBoolean() ? randomClusters() : SearchResponse.Clusters.EMPTY,
             null

--- a/test/framework/src/main/java/org/opensearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/opensearch/search/RandomSearchRequestGenerator.java
@@ -131,6 +131,9 @@ public class RandomSearchRequestGenerator {
         if (randomBoolean()) {
             searchRequest.setCancelAfterTimeInterval(TimeValue.parseTimeValue(randomTimeValue(), null, "cancel_after_time_interval"));
         }
+        if (randomBoolean()) {
+            searchRequest.setPhaseTookQueryParamEnabled(randomBoolean());
+        }
         return searchRequest;
     }
 


### PR DESCRIPTION
### Description

Per Request level tracking: As part of this, we will offer further breakdown of existing took time in search response. To do this, we will introduce a new field(phase_took) in search response which will give more insights/visibility into overall time taken by different search phases(query/fetch/canMatch etc) to the clients.

```
% curl -XGET 'localhost:9200/_search?pretty&phase_took' -H 'Content-Type: application/json' -d'
{                                                
 "query": { "query_string": { "query": "abc" } }
}'
{
  "took" : 92,
  "phase_took" : {
    "dfs_prequery" : 0,
    "can_match" : 0,
    "query" : 66,
    "fetch" : 4,
    "expand_search" : 0
  },
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 0,
      "relation" : "eq"
    },
    "max_score" : null,
    "hits" : [ ]
  }
}
```

### Testing
Local testing with IDE debugger 
https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md#launching-and-debugging-from-an-ide

1. Create an index and ingest some data
```
curl -X PUT "localhost:9200/test2?pretty" -H 'Content-Type: application/json' -d' 
{                                                
  "settings": {
    "number_of_shards": 10
  }
}'

curl -X POST "localhost:9200/_bulk?pretty" -H 'Content-Type: application/json' -d'
{ "index" : { "_index" : "test2", "_id" : "1" } }
{ "field1" : "value1" }                          
{ "index" : { "_index" : "test2", "_id" : "2" } }
{ "field2" : "value2" }
{ "index" : { "_index" : "test2", "_id" : "3" } }
{ "field3" : "value3" }
{ "index" : { "_index" : "test2", "_id" : "4" } }
{ "field4" : "value4" }
'
```

2. Search request with `phase_took` query parameter
```
curl -XGET 'localhost:9200/_search?pretty&phase_took' -H 'Content-Type: application/json' -d'
{
 "query": { "query_string": { "query": "abc" } }
}'
```

3. Update and verify cluster setting
```
curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d '{"transient" : {"search.phase_took_enabled" : true}}'
curl -X GET "localhost:9200/_cluster/settings?pretty&flat_settings"
```

4. Search request without query parameter
```
curl -XGET 'localhost:9200/_search?pretty' -H 'Content-Type: application/json' -d'
{
 "query": { "query_string": { "query": "abc" } }
}'
```