### PR TITLE
Tracing instrumentation at deep search path

### DIFF
--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -439,9 +439,9 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         this.searchRequestContext.getSearchRequestOperationsListener().onPhaseEnd(this, searchRequestContext);
     }
 
-    private void onPhaseStart(SearchPhase phase) {
+    private void onPhaseStart(SearchPhase phase, SearchRequestContext searchRequestContext) {
         setCurrentPhase(phase);
-        this.searchRequestContext.getSearchRequestOperationsListener().onPhaseStart(this);
+        this.searchRequestContext.getSearchRequestOperationsListener().onPhaseStart(this, searchRequestContext);
     }
 
     private void onRequestEnd(SearchRequestContext searchRequestContext) {
@@ -450,7 +450,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
 
     private void executePhase(SearchPhase phase) {
         try {
-            onPhaseStart(phase);
+            onPhaseStart(phase, searchRequestContext);
             phase.recordAndRun();
         } catch (Exception e) {
             if (logger.isDebugEnabled()) {
@@ -714,7 +714,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
 
     @Override
     public final void onPhaseFailure(SearchPhase phase, String msg, Throwable cause) {
-        this.searchRequestContext.getSearchRequestOperationsListener().onPhaseFailure(this);
+        this.searchRequestContext.getSearchRequestOperationsListener().onPhaseFailure(this, searchRequestContext);
         raisePhaseFailure(new SearchPhaseExecutionException(phase.getName(), msg, cause, buildShardFailures()));
     }
 

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestContext.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestContext.java
@@ -11,6 +11,7 @@ package org.opensearch.action.search;
 import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.search.TotalHits;
 import org.opensearch.common.annotation.InternalApi;
+import org.opensearch.telemetry.tracing.Span;
 
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -24,12 +25,14 @@ import java.util.Map;
  * @opensearch.internal
  */
 @InternalApi
-class SearchRequestContext {
+public class SearchRequestContext {
     private final SearchRequestOperationsListener searchRequestOperationsListener;
     private long absoluteStartNanos;
     private final Map<String, Long> phaseTookMap;
     private TotalHits totalHits;
     private final EnumMap<ShardStatsFieldNames, Integer> shardStats;
+    private Span requestSpan;
+    private Span phaseSpan;
 
     /**
      * This constructor is for testing only
@@ -76,7 +79,7 @@ class SearchRequestContext {
         this.totalHits = totalHits;
     }
 
-    TotalHits totalHits() {
+    public TotalHits totalHits() {
         return totalHits;
     }
 
@@ -87,7 +90,7 @@ class SearchRequestContext {
         this.shardStats.put(ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_FAILED, failed);
     }
 
-    String formattedShardStats() {
+    public String formattedShardStats() {
         if (shardStats.isEmpty()) {
             return "";
         } else {
@@ -104,6 +107,22 @@ class SearchRequestContext {
                 shardStats.get(ShardStatsFieldNames.SEARCH_REQUEST_SLOWLOG_SHARD_FAILED)
             );
         }
+    }
+
+    public void setRequestSpan(Span requestSpan) {
+        this.requestSpan = requestSpan;
+    }
+
+    public Span getRequestSpan() {
+        return requestSpan;
+    }
+
+    public void setPhaseSpan(Span phaseSpan) {
+        this.phaseSpan = phaseSpan;
+    }
+
+    public Span getPhaseSpan() {
+        return phaseSpan;
     }
 }
 

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestCoordinatorTrace.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestCoordinatorTrace.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.search;
+
+import org.opensearch.telemetry.tracing.AttributeNames;
+import org.opensearch.telemetry.tracing.SpanBuilder;
+import org.opensearch.telemetry.tracing.SpanContext;
+import org.opensearch.telemetry.tracing.SpanScope;
+import org.opensearch.telemetry.tracing.Tracer;
+
+import static org.opensearch.core.common.Strings.capitalize;
+
+/**
+ * Listener for search request tracing on the coordinator node
+ *
+ * @opensearch.internal
+ */
+public final class SearchRequestCoordinatorTrace extends SearchRequestOperationsListener {
+    private final Tracer tracer;
+
+    public SearchRequestCoordinatorTrace(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        searchRequestContext.setPhaseSpan(
+            tracer.startSpan(
+                SpanBuilder.from(
+                    "coordinator" + capitalize(context.getCurrentPhase().getName()),
+                    new SpanContext(searchRequestContext.getRequestSpan())
+                )
+            )
+        );
+        SpanScope spanScope = tracer.withSpanInScope(searchRequestContext.getPhaseSpan());
+    }
+
+    @Override
+    void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        searchRequestContext.getPhaseSpan().endSpan();
+    }
+
+    @Override
+    void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        searchRequestContext.getPhaseSpan().endSpan();
+    }
+
+    @Override
+    void onRequestStart(SearchRequestContext searchRequestContext) {
+        searchRequestContext.setRequestSpan(tracer.startSpan(SpanBuilder.from("coordinatorRequest")));
+    }
+
+    @Override
+    void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        // add response-related attributes on request end
+        if (searchRequestContext.totalHits() != null) {
+            searchRequestContext.getRequestSpan().addAttribute(AttributeNames.TOTAL_HITS, searchRequestContext.totalHits().toString());
+        }
+        if (!searchRequestContext.formattedShardStats().equals("")) {
+            searchRequestContext.getRequestSpan().addAttribute(AttributeNames.SHARDS, searchRequestContext.formattedShardStats());
+        }
+        searchRequestContext.getRequestSpan().addAttribute(AttributeNames.SOURCE, context.getRequest().source().toString());
+        searchRequestContext.getRequestSpan().endSpan();
+    }
+}

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
@@ -22,11 +22,11 @@ import java.util.List;
 @InternalApi
 abstract class SearchRequestOperationsListener {
 
-    abstract void onPhaseStart(SearchPhaseContext context);
+    abstract void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext);
 
     abstract void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext);
 
-    abstract void onPhaseFailure(SearchPhaseContext context);
+    abstract void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext);
 
     void onRequestStart(SearchRequestContext searchRequestContext) {}
 
@@ -48,10 +48,10 @@ abstract class SearchRequestOperationsListener {
         }
 
         @Override
-        void onPhaseStart(SearchPhaseContext context) {
+        void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
             for (SearchRequestOperationsListener listener : listeners) {
                 try {
-                    listener.onPhaseStart(context);
+                    listener.onPhaseStart(context, searchRequestContext);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onPhaseStart listener [{}] failed", listener), e);
                 }
@@ -70,10 +70,10 @@ abstract class SearchRequestOperationsListener {
         }
 
         @Override
-        void onPhaseFailure(SearchPhaseContext context) {
+        void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
             for (SearchRequestOperationsListener listener : listeners) {
                 try {
-                    listener.onPhaseFailure(context);
+                    listener.onPhaseFailure(context, searchRequestContext);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onPhaseFailure listener [{}] failed", listener), e);
                 }

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestSlowLog.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestSlowLog.java
@@ -134,13 +134,13 @@ public final class SearchRequestSlowLog extends SearchRequestOperationsListener 
     }
 
     @Override
-    void onPhaseStart(SearchPhaseContext context) {}
+    void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
     @Override
     void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
     @Override
-    void onPhaseFailure(SearchPhaseContext context) {}
+    void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
     @Override
     void onRequestStart(SearchRequestContext searchRequestContext) {}

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestStats.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestStats.java
@@ -46,7 +46,7 @@ public final class SearchRequestStats extends SearchRequestOperationsListener {
     }
 
     @Override
-    void onPhaseStart(SearchPhaseContext context) {
+    void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
         phaseStatsMap.get(context.getCurrentPhase().getSearchPhaseName()).current.inc();
     }
 
@@ -59,7 +59,7 @@ public final class SearchRequestStats extends SearchRequestOperationsListener {
     }
 
     @Override
-    void onPhaseFailure(SearchPhaseContext context) {
+    void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
         phaseStatsMap.get(context.getCurrentPhase().getSearchPhaseName()).current.dec();
     }
 

--- a/server/src/main/java/org/opensearch/index/IndexModule.java
+++ b/server/src/main/java/org/opensearch/index/IndexModule.java
@@ -87,6 +87,7 @@ import org.opensearch.plugins.IndexStorePlugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.aggregations.support.ValuesSourceRegistry;
+import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -296,6 +297,7 @@ public final class IndexModule {
     private final AtomicBoolean frozen = new AtomicBoolean(false);
     private final BooleanSupplier allowExpensiveQueries;
     private final Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories;
+    private final Tracer tracer;
 
     /**
      * Construct the index module for the index with the specified index settings. The index module contains extension points for plugins
@@ -314,7 +316,8 @@ public final class IndexModule {
         final Map<String, IndexStorePlugin.DirectoryFactory> directoryFactories,
         final BooleanSupplier allowExpensiveQueries,
         final IndexNameExpressionResolver expressionResolver,
-        final Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories
+        final Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories,
+        final Tracer tracer
     ) {
         this.indexSettings = indexSettings;
         this.analysisRegistry = analysisRegistry;
@@ -326,6 +329,7 @@ public final class IndexModule {
         this.allowExpensiveQueries = allowExpensiveQueries;
         this.expressionResolver = expressionResolver;
         this.recoveryStateFactories = recoveryStateFactories;
+        this.tracer = tracer;
     }
 
     /**
@@ -664,7 +668,8 @@ public final class IndexModule {
                 translogFactorySupplier,
                 clusterDefaultRefreshIntervalSupplier,
                 clusterRemoteTranslogBufferIntervalSupplier,
-                recoverySettings
+                recoverySettings,
+                tracer
             );
             success = true;
             return indexService;

--- a/server/src/main/java/org/opensearch/index/IndexService.java
+++ b/server/src/main/java/org/opensearch/index/IndexService.java
@@ -102,6 +102,7 @@ import org.opensearch.indices.replication.checkpoint.SegmentReplicationCheckpoin
 import org.opensearch.plugins.IndexStorePlugin;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.aggregations.support.ValuesSourceRegistry;
+import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
@@ -182,6 +183,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final Supplier<TimeValue> clusterDefaultRefreshIntervalSupplier;
     private final Supplier<TimeValue> clusterRemoteTranslogBufferIntervalSupplier;
     private final RecoverySettings recoverySettings;
+    private final Tracer tracer;
 
     public IndexService(
         IndexSettings indexSettings,
@@ -217,7 +219,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         BiFunction<IndexSettings, ShardRouting, TranslogFactory> translogFactorySupplier,
         Supplier<TimeValue> clusterDefaultRefreshIntervalSupplier,
         Supplier<TimeValue> clusterRemoteTranslogBufferIntervalSupplier,
-        RecoverySettings recoverySettings
+        RecoverySettings recoverySettings,
+        Tracer tracer
     ) {
         super(indexSettings);
         this.allowExpensiveQueries = allowExpensiveQueries;
@@ -295,6 +298,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         this.translogFactorySupplier = translogFactorySupplier;
         this.clusterRemoteTranslogBufferIntervalSupplier = clusterRemoteTranslogBufferIntervalSupplier;
         this.recoverySettings = recoverySettings;
+        this.tracer = tracer;
         updateFsyncTaskIfNecessary();
     }
 
@@ -528,7 +532,8 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 remoteStoreStatsTrackerFactory,
                 clusterRemoteTranslogBufferIntervalSupplier,
                 nodeEnv.nodeId(),
-                recoverySettings
+                recoverySettings,
+                tracer
             );
             eventListener.indexShardStateChanged(indexShard, null, indexShard.state(), "shard created");
             eventListener.afterIndexShardCreated(indexShard);

--- a/server/src/main/java/org/opensearch/index/shard/SearchShardTrace.java
+++ b/server/src/main/java/org/opensearch/index/shard/SearchShardTrace.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.shard;
+
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.telemetry.tracing.Span;
+import org.opensearch.telemetry.tracing.SpanBuilder;
+import org.opensearch.telemetry.tracing.Tracer;
+
+/**
+ * Tracer listener for shard-level search requests
+ *
+ * @opensearch.internal
+ */
+public class SearchShardTrace implements SearchOperationListener {
+    private final Tracer tracer;
+    private Span querySpan;
+    private Span fetchSpan;
+
+    SearchShardTrace(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public void onPreQueryPhase(SearchContext searchContext) {
+        SearchOperationListener.super.onPreQueryPhase(searchContext);
+        querySpan = tracer.startSpan(SpanBuilder.from("shardQuery", searchContext));
+    }
+
+    @Override
+    public void onQueryPhase(SearchContext searchContext, long tookInNanos) {
+        SearchOperationListener.super.onQueryPhase(searchContext, tookInNanos);
+        querySpan.endSpan();
+    }
+
+    @Override
+    public void onPreFetchPhase(SearchContext searchContext) {
+        SearchOperationListener.super.onPreFetchPhase(searchContext);
+        fetchSpan = tracer.startSpan(SpanBuilder.from("shardFetch", searchContext));
+    }
+
+    @Override
+    public void onFetchPhase(SearchContext searchContext, long tookInNanos) {
+        SearchOperationListener.super.onFetchPhase(searchContext, tookInNanos);
+        fetchSpan.endSpan();
+    }
+}

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -160,6 +160,7 @@ import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.query.QueryPhase;
 import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.io.Closeable;
@@ -352,6 +353,7 @@ public class IndicesService extends AbstractLifecycleComponent
     private final FileCacheCleaner fileCacheCleaner;
 
     private final SearchRequestStats searchRequestStats;
+    private final Tracer tracer;
 
     @Override
     protected void doStart() {
@@ -385,7 +387,8 @@ public class IndicesService extends AbstractLifecycleComponent
         FileCacheCleaner fileCacheCleaner,
         SearchRequestStats searchRequestStats,
         @Nullable RemoteStoreStatsTrackerFactory remoteStoreStatsTrackerFactory,
-        RecoverySettings recoverySettings
+        RecoverySettings recoverySettings,
+        Tracer tracer
     ) {
         this.settings = settings;
         this.threadPool = threadPool;
@@ -483,6 +486,7 @@ public class IndicesService extends AbstractLifecycleComponent
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING, this::setClusterRemoteTranslogBufferInterval);
         this.recoverySettings = recoverySettings;
+        this.tracer = tracer;
     }
 
     /**
@@ -851,7 +855,8 @@ public class IndicesService extends AbstractLifecycleComponent
             directoryFactories,
             () -> allowExpensiveQueries,
             indexNameExpressionResolver,
-            recoveryStateFactories
+            recoveryStateFactories,
+            tracer
         );
         for (IndexingOperationListener operationListener : indexingOperationListeners) {
             indexModule.addIndexOperationListener(operationListener);
@@ -941,7 +946,8 @@ public class IndicesService extends AbstractLifecycleComponent
             directoryFactories,
             () -> allowExpensiveQueries,
             indexNameExpressionResolver,
-            recoveryStateFactories
+            recoveryStateFactories,
+            tracer
         );
         pluginsService.onIndexModule(indexModule);
         return indexModule.newIndexMapperService(xContentRegistry, mapperRegistry, scriptService);

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -46,6 +46,7 @@ import org.opensearch.action.ActionType;
 import org.opensearch.action.admin.cluster.snapshots.status.TransportNodesSnapshotsStatus;
 import org.opensearch.action.search.SearchExecutionStatsCollector;
 import org.opensearch.action.search.SearchPhaseController;
+import org.opensearch.action.search.SearchRequestCoordinatorTrace;
 import org.opensearch.action.search.SearchRequestSlowLog;
 import org.opensearch.action.search.SearchRequestStats;
 import org.opensearch.action.search.SearchTransportService;
@@ -785,6 +786,7 @@ public class Node implements Closeable {
 
             final SearchRequestStats searchRequestStats = new SearchRequestStats();
             final SearchRequestSlowLog searchRequestSlowLog = new SearchRequestSlowLog(clusterService);
+            final SearchRequestCoordinatorTrace searchRequestCoordinatorTrace = new SearchRequestCoordinatorTrace(tracer);
 
             remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, settings);
             final IndicesService indicesService = new IndicesService(
@@ -813,7 +815,8 @@ public class Node implements Closeable {
                 fileCacheCleaner,
                 searchRequestStats,
                 remoteStoreStatsTrackerFactory,
-                recoverySettings
+                recoverySettings,
+                tracer
             );
 
             final IngestService ingestService = new IngestService(
@@ -1271,6 +1274,7 @@ public class Node implements Closeable {
                 b.bind(Tracer.class).toInstance(tracer);
                 b.bind(SearchRequestStats.class).toInstance(searchRequestStats);
                 b.bind(SearchRequestSlowLog.class).toInstance(searchRequestSlowLog);
+                b.bind(SearchRequestCoordinatorTrace.class).toInstance(searchRequestCoordinatorTrace);
                 b.bind(MetricsRegistry.class).toInstance(metricsRegistry);
                 b.bind(RemoteClusterStateService.class).toProvider(() -> remoteClusterStateService);
                 b.bind(PersistedStateRegistry.class).toInstance(persistedStateRegistry);

--- a/server/src/main/java/org/opensearch/telemetry/tracing/AttributeNames.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/AttributeNames.java
@@ -94,4 +94,19 @@ public final class AttributeNames {
      * Refresh Policy
      */
     public static final String REFRESH_POLICY = "refresh_policy";
+
+    /**
+     * Search Request Source
+     */
+    public static final String SOURCE = "source";
+
+    /**
+     * Search Response Shard Stats
+     */
+    public static final String SHARDS = "shards";
+
+    /**
+     * Search Response Total Hits
+     */
+    public static final String TOTAL_HITS = "total_hits";
 }

--- a/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/opensearch/action/search/AbstractSearchAsyncActionTests.java
@@ -55,6 +55,7 @@ import org.opensearch.search.internal.InternalSearchResponse;
 import org.opensearch.search.internal.ShardSearchContextId;
 import org.opensearch.search.internal.ShardSearchRequest;
 import org.opensearch.search.query.QuerySearchResult;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.InternalAggregationTestCase;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerSupport.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerSupport.java
@@ -13,7 +13,7 @@ package org.opensearch.action.search;
  */
 public interface SearchRequestOperationsListenerSupport {
     default void onPhaseStart(SearchRequestOperationsListener listener, SearchPhaseContext context) {
-        listener.onPhaseStart(context);
+        listener.onPhaseStart(context, new SearchRequestContext());
     }
 
     default void onPhaseEnd(SearchRequestOperationsListener listener, SearchPhaseContext context) {

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerTests.java
@@ -29,7 +29,7 @@ public class SearchRequestOperationsListenerTests extends OpenSearchTestCase {
         SearchRequestOperationsListener testListener = new SearchRequestOperationsListener() {
 
             @Override
-            public void onPhaseStart(SearchPhaseContext context) {
+            public void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
                 searchPhaseMap.get(context.getCurrentPhase().getSearchPhaseName()).current.inc();
             }
 
@@ -40,7 +40,7 @@ public class SearchRequestOperationsListenerTests extends OpenSearchTestCase {
             }
 
             @Override
-            public void onPhaseFailure(SearchPhaseContext context) {
+            public void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
                 searchPhaseMap.get(context.getCurrentPhase().getSearchPhaseName()).current.dec();
             }
         };
@@ -58,11 +58,12 @@ public class SearchRequestOperationsListenerTests extends OpenSearchTestCase {
 
         SearchPhaseContext ctx = mock(SearchPhaseContext.class);
         SearchPhase searchPhase = mock(SearchPhase.class);
+        SearchRequestContext searchRequestContext = mock(SearchRequestContext.class);
 
         for (SearchPhaseName searchPhaseName : SearchPhaseName.values()) {
             when(ctx.getCurrentPhase()).thenReturn(searchPhase);
             when(searchPhase.getSearchPhaseName()).thenReturn(searchPhaseName);
-            compositeListener.onPhaseStart(ctx);
+            compositeListener.onPhaseStart(ctx, searchRequestContext);
             assertEquals(totalListeners, searchPhaseMap.get(searchPhaseName).current.count());
         }
     }

--- a/server/src/test/java/org/opensearch/action/search/SearchTimeProviderTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchTimeProviderTests.java
@@ -22,13 +22,14 @@ public class SearchTimeProviderTests extends OpenSearchTestCase {
         TransportSearchAction.SearchTimeProvider testTimeProvider = new TransportSearchAction.SearchTimeProvider(0, 0, () -> 0);
         SearchPhaseContext ctx = mock(SearchPhaseContext.class);
         SearchPhase mockSearchPhase = mock(SearchPhase.class);
+        SearchRequestContext mockSearchRequestContext = mock(SearchRequestContext.class);
         when(ctx.getCurrentPhase()).thenReturn(mockSearchPhase);
 
         for (SearchPhaseName searchPhaseName : SearchPhaseName.values()) {
             when(mockSearchPhase.getSearchPhaseName()).thenReturn(searchPhaseName);
-            testTimeProvider.onPhaseStart(ctx);
+            testTimeProvider.onPhaseStart(ctx, mockSearchRequestContext);
             assertNull(testTimeProvider.getPhaseTookTime(searchPhaseName));
-            testTimeProvider.onPhaseFailure(ctx);
+            testTimeProvider.onPhaseFailure(ctx, mockSearchRequestContext);
             assertNull(testTimeProvider.getPhaseTookTime(searchPhaseName));
         }
     }
@@ -38,12 +39,13 @@ public class SearchTimeProviderTests extends OpenSearchTestCase {
 
         SearchPhaseContext ctx = mock(SearchPhaseContext.class);
         SearchPhase mockSearchPhase = mock(SearchPhase.class);
+        SearchRequestContext mockSearchRequestContext = mock(SearchRequestContext.class);
         when(ctx.getCurrentPhase()).thenReturn(mockSearchPhase);
 
         for (SearchPhaseName searchPhaseName : SearchPhaseName.values()) {
             when(mockSearchPhase.getSearchPhaseName()).thenReturn(searchPhaseName);
             long tookTimeInMillis = randomIntBetween(1, 100);
-            testTimeProvider.onPhaseStart(ctx);
+            testTimeProvider.onPhaseStart(ctx, mockSearchRequestContext);
             long startTime = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(tookTimeInMillis);
             when(mockSearchPhase.getStartTimeInNanos()).thenReturn(startTime);
             assertNull(testTimeProvider.getPhaseTookTime(searchPhaseName));

--- a/server/src/test/java/org/opensearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/opensearch/index/IndexModuleTests.java
@@ -276,7 +276,8 @@ public class IndexModuleTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             () -> true,
             new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY)),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            NoopTracer.INSTANCE
         );
         module.setReaderWrapper(s -> new Wrapper());
 
@@ -302,7 +303,8 @@ public class IndexModuleTests extends OpenSearchTestCase {
             indexStoreFactories,
             () -> true,
             new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY)),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            NoopTracer.INSTANCE
         );
 
         final IndexService indexService = newIndexService(module);
@@ -630,7 +632,8 @@ public class IndexModuleTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             () -> true,
             new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY)),
-            recoveryStateFactories
+            recoveryStateFactories,
+            NoopTracer.INSTANCE
         );
 
         final IndexService indexService = newIndexService(module);
@@ -662,7 +665,8 @@ public class IndexModuleTests extends OpenSearchTestCase {
             Collections.emptyMap(),
             () -> true,
             new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY)),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            NoopTracer.INSTANCE
         );
     }
 

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -2075,7 +2075,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     fileCacheCleaner,
                     null,
                     new RemoteStoreStatsTrackerFactory(clusterService, settings),
-                    DefaultRecoverySettings.INSTANCE
+                    DefaultRecoverySettings.INSTANCE,
+                    NoopTracer.INSTANCE
                 );
                 final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
                 snapshotShardsService = new SnapshotShardsService(
@@ -2312,7 +2313,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                         ),
                         null,
                         new SearchRequestSlowLog(clusterService),
-                        NoopMetricsRegistry.INSTANCE
+                        NoopMetricsRegistry.INSTANCE,
+                        NoopTracer.INSTANCE
                     )
                 );
                 actions.put(

--- a/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/index/shard/IndexShardTestCase.java
@@ -152,6 +152,7 @@ import org.opensearch.repositories.blobstore.BlobStoreTestUtil;
 import org.opensearch.repositories.blobstore.OpenSearchBlobStoreRepositoryIntegTestCase;
 import org.opensearch.repositories.fs.FsRepository;
 import org.opensearch.snapshots.Snapshot;
+import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.DummyShardLock;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
@@ -703,7 +704,8 @@ public abstract class IndexShardTestCase extends OpenSearchTestCase {
                 remoteStoreStatsTrackerFactory,
                 () -> IndexSettings.DEFAULT_REMOTE_TRANSLOG_BUFFER_INTERVAL,
                 "dummy-node",
-                DefaultRecoverySettings.INSTANCE
+                DefaultRecoverySettings.INSTANCE,
+                NoopTracer.INSTANCE
             );
             indexShard.addShardFailureCallback(DEFAULT_SHARD_FAILURE_HANDLER);
             if (remoteStoreStatsTrackerFactory != null) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Draft PR for internal review

Adds tracing for the following search paths:
1. Coordinator node
2. Coordinator node search phases
3. Shard query and fetch phases

```
% curl -X PUT "localhost:9200/test2?pretty" -H 'Content-Type: application/json' -d'                                                                    
{                                                  
  "settings": {
    "number_of_shards": 10
  }
}'

% curl -X POST "localhost:9200/_bulk?pretty" -H 'Content-Type: application/json' -d'
{ "index" : { "_index" : "test2", "_id" : "1" } }
{ "field1" : "value1" }
{ "index" : { "_index" : "test2", "_id" : "2" } }
{ "field2" : "value2" }
'

% curl -XGET 'localhost:9200/_search?pretty&phase_took' -H 'X-Opaque-Id: my-id' -H 'Content-Type: application/json' -d'{
 "query": { "match_all": {} }
}'

```
![Screenshot 2023-12-13 at 9 57 15 AM](https://github.com/dzane17/OpenSearch/assets/38449481/f542d1ea-d279-4945-8015-6a621411d4d7)

### Sample Spans
##### 1. Coordinator node
![Screenshot 2023-12-13 at 2 10 42 PM](https://github.com/dzane17/OpenSearch/assets/38449481/949ccb76-0b51-4766-934c-eb268561a422)

```
{
   "traceId":"e522537a055adc6fc59667b58347942c",
   "spanId":"5b42e305497d91f8",
   "parentSpanId":"dab8a74cc0bb10c1",
   "name":"coordinatorRequest",
   "kind":2,
   "startTimeUnixNano":"1702333271222480100",
   "endTimeUnixNano":"1702333271229240384",
   "attributes":[
      {
         "key":"thread.name",
         "value":{
            "stringValue":"opensearch[88665a158598.ant.amazon.com][transport_worker][T#8]"
         }
      },
      {
         "key":"total_hits",
         "value":{
            "stringValue":"4 hits"
         }
      },
      {
         "key":"shards",
         "value":{
            "stringValue":"{total:2, successful:2, skipped:0, failed:0}"
         }
      }
   ],
   "status":{
      
   }
}
```

##### 2. Coordinator node phase
![Screenshot 2023-12-13 at 2 11 40 PM](https://github.com/dzane17/OpenSearch/assets/38449481/e6ff6ae2-945d-4fd7-8712-88032ebb97e7)

```
{
   "traceId":"e522537a055adc6fc59667b58347942c",
   "spanId":"c8ef2d7ad2584a6c",
   "parentSpanId":"5b42e305497d91f8",
   "name":"coordinatorQuery",
   "kind":2,
   "startTimeUnixNano":"1702333271223157629",
   "endTimeUnixNano":"1702333271225489595",
   "attributes":[
      {
         "key":"thread.name",
         "value":{
            "stringValue":"opensearch[88665a158598.ant.amazon.com][transport_worker][T#8]"
         }
      }
   ],
   "status":{
      
   }
}
```

##### 3. Shard phase
![Screenshot 2023-12-13 at 2 14 18 PM](https://github.com/dzane17/OpenSearch/assets/38449481/991e154c-94c0-46f7-910e-548b0927f1a8)

````
{
   "traceId":"e522537a055adc6fc59667b58347942c",
   "spanId":"637c47eaa1d956da",
   "parentSpanId":"c8ef2d7ad2584a6c",
   "name":"shardQuery",
   "kind":2,
   "startTimeUnixNano":"1702333271224104730",
   "endTimeUnixNano":"1702333271224698102",
   "attributes":[
      {
         "key":"thread.name",
         "value":{
            "stringValue":"opensearch[88665a158598.ant.amazon.com][search][T#3]"
         }
      },
      {
         "key":"index",
         "value":{
            "stringValue":"test1"
         }
      },
      {
         "key":"shard_id",
         "value":{
            "intValue":"0"
         }
      }
   ],
   "status":{
      
   }
}
````
