### PR TITLE
Tracing instrumentation at deep search path

### DIFF
--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -443,7 +443,10 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
 
     private void onPhaseStart(SearchPhase phase, SearchRequestContext searchRequestContext) {
         setCurrentPhase(phase);
-        this.searchRequestContext.getSearchRequestOperationsListener().onPhaseStart(this, searchRequestContext);
+        try {
+            SearchPhaseName.valueOf(phase.getSearchPhaseName().toString());
+            this.searchRequestContext.getSearchRequestOperationsListener().onPhaseStart(this, searchRequestContext);
+        } catch (IllegalArgumentException ignored) {}
     }
 
     private void onRequestEnd(SearchRequestContext searchRequestContext) {

--- a/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/opensearch/action/search/AbstractSearchAsyncAction.java
@@ -220,6 +220,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
                     null
                 )
             );
+            searchRequestContext.getSearchRequestOperationsListener().onRequestEnd(searchRequestContext);
             return;
         }
         executePhase(this);
@@ -439,18 +440,18 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         this.searchRequestContext.getSearchRequestOperationsListener().onPhaseEnd(this, searchRequestContext);
     }
 
-    private void onPhaseStart(SearchPhase phase) {
+    private void onPhaseStart(SearchPhase phase, SearchRequestContext searchRequestContext) {
         setCurrentPhase(phase);
-        this.searchRequestContext.getSearchRequestOperationsListener().onPhaseStart(this);
+        this.searchRequestContext.getSearchRequestOperationsListener().onPhaseStart(this, searchRequestContext);
     }
 
     private void onRequestEnd(SearchRequestContext searchRequestContext) {
-        this.searchRequestContext.getSearchRequestOperationsListener().onRequestEnd(this, searchRequestContext);
+        this.searchRequestContext.getSearchRequestOperationsListener().onRequestEnd(searchRequestContext);
     }
 
     private void executePhase(SearchPhase phase) {
         try {
-            onPhaseStart(phase);
+            onPhaseStart(phase, searchRequestContext);
             phase.recordAndRun();
         } catch (Exception e) {
             if (logger.isDebugEnabled()) {
@@ -703,6 +704,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
                     searchContextId = null;
                 }
             }
+            searchRequestContext.setSearchTask(getTask());
             searchRequestContext.setTotalHits(internalSearchResponse.hits().getTotalHits());
             searchRequestContext.setShardStats(results.getNumShards(), successfulOps.get(), skippedOps.get(), failures.length);
             onPhaseEnd(searchRequestContext);
@@ -714,7 +716,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
 
     @Override
     public final void onPhaseFailure(SearchPhase phase, String msg, Throwable cause) {
-        this.searchRequestContext.getSearchRequestOperationsListener().onPhaseFailure(this);
+        this.searchRequestContext.getSearchRequestOperationsListener().onPhaseFailure(this, searchRequestContext);
         raisePhaseFailure(new SearchPhaseExecutionException(phase.getName(), msg, cause, buildShardFailures()));
     }
 

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestContext.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestContext.java
@@ -13,6 +13,7 @@ import org.apache.lucene.search.TotalHits;
 import org.opensearch.common.annotation.InternalApi;
 import org.opensearch.telemetry.tracing.Span;
 import org.opensearch.telemetry.tracing.Tracer;
+import org.opensearch.telemetry.tracing.noop.NoopSpan;
 import org.opensearch.telemetry.tracing.noop.NoopTracer;
 
 import java.util.EnumMap;
@@ -67,6 +68,9 @@ class SearchRequestContext {
         this.absoluteStartNanos = System.nanoTime();
         this.phaseTookMap = new HashMap<>();
         this.shardStats = new EnumMap<>(ShardStatsFieldNames.class);
+        this.tracer = tracer;
+        this.requestSpan = NoopSpan.INSTANCE;
+        this.phaseSpan = NoopSpan.INSTANCE;
     }
 
     public SearchRequest getSearchRequest() {

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestCoordinatorTrace.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestCoordinatorTrace.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.search;
+
+import org.opensearch.telemetry.tracing.AttributeNames;
+import org.opensearch.telemetry.tracing.Span;
+import org.opensearch.telemetry.tracing.SpanBuilder;
+import org.opensearch.telemetry.tracing.SpanContext;
+import org.opensearch.telemetry.tracing.SpanScope;
+import org.opensearch.telemetry.tracing.Tracer;
+
+import static org.opensearch.core.common.Strings.capitalize;
+
+/**
+ * Listener for search request tracing on the coordinator node
+ *
+ * @opensearch.internal
+ */
+public final class SearchRequestCoordinatorTrace extends SearchRequestOperationsListener {
+    private final Tracer tracer;
+
+    public SearchRequestCoordinatorTrace(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        if (searchRequestContext.getPhaseSpan() != null) {
+            searchRequestContext.getPhaseSpan().endSpan();
+        }
+        searchRequestContext.setPhaseSpan(
+            tracer.startSpan(
+                SpanBuilder.from(
+                    "coordinator" + capitalize(context.getCurrentPhase().getName()),
+                    new SpanContext(searchRequestContext.getRequestSpan())
+                )
+            )
+        );
+        SpanScope spanScope = tracer.withSpanInScope(searchRequestContext.getPhaseSpan());
+    }
+
+    @Override
+    void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        searchRequestContext.getPhaseSpan().endSpan();
+        searchRequestContext.setPhaseSpan(null);
+    }
+
+    @Override
+    void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        searchRequestContext.getPhaseSpan().endSpan();
+        searchRequestContext.setPhaseSpan(null);
+    }
+
+    @Override
+    void onRequestEnd(SearchRequestContext searchRequestContext) {
+        Span requestSpan = searchRequestContext.getRequestSpan();
+
+        // add response-related attributes on request end
+        requestSpan.addAttribute(
+            AttributeNames.TOTAL_HITS,
+            searchRequestContext.totalHits() == null ? "0" : searchRequestContext.totalHits().toString()
+        );
+        requestSpan.addAttribute(
+            AttributeNames.SHARDS,
+            searchRequestContext.formattedShardStats().isEmpty() ? "no data" : searchRequestContext.formattedShardStats()
+        );
+        requestSpan.addAttribute(
+            AttributeNames.SOURCE,
+            searchRequestContext.getSearchRequest().source() == null
+                ? "no source"
+                : searchRequestContext.getSearchRequest().source().toString()
+        );
+    }
+}

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestCoordinatorTrace.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestCoordinatorTrace.java
@@ -30,9 +30,6 @@ public final class SearchRequestCoordinatorTrace extends SearchRequestOperations
 
     @Override
     void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
-        if (searchRequestContext.getPhaseSpan() != null) {
-            searchRequestContext.getPhaseSpan().endSpan();
-        }
         searchRequestContext.setPhaseSpan(
             tracer.startSpan(
                 SpanBuilder.from(

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestCoordinatorTrace.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestCoordinatorTrace.java
@@ -12,7 +12,6 @@ import org.opensearch.telemetry.tracing.AttributeNames;
 import org.opensearch.telemetry.tracing.Span;
 import org.opensearch.telemetry.tracing.SpanBuilder;
 import org.opensearch.telemetry.tracing.SpanContext;
-import org.opensearch.telemetry.tracing.SpanScope;
 import org.opensearch.telemetry.tracing.Tracer;
 
 import static org.opensearch.core.common.Strings.capitalize;
@@ -37,24 +36,21 @@ public final class SearchRequestCoordinatorTrace extends SearchRequestOperations
         searchRequestContext.setPhaseSpan(
             tracer.startSpan(
                 SpanBuilder.from(
-                    "coordinator" + capitalize(context.getCurrentPhase().getName()),
+                    "coord" + capitalize(context.getCurrentPhase().getName()),
                     new SpanContext(searchRequestContext.getRequestSpan())
                 )
             )
         );
-        SpanScope spanScope = tracer.withSpanInScope(searchRequestContext.getPhaseSpan());
     }
 
     @Override
     void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
         searchRequestContext.getPhaseSpan().endSpan();
-        searchRequestContext.setPhaseSpan(null);
     }
 
     @Override
     void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
         searchRequestContext.getPhaseSpan().endSpan();
-        searchRequestContext.setPhaseSpan(null);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestOperationsListener.java
@@ -31,15 +31,15 @@ public abstract class SearchRequestOperationsListener {
         this.enabled = enabled;
     }
 
-    abstract void onPhaseStart(SearchPhaseContext context);
+    abstract void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext);
 
     abstract void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext);
 
-    abstract void onPhaseFailure(SearchPhaseContext context);
+    abstract void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext);
 
     void onRequestStart(SearchRequestContext searchRequestContext) {}
 
-    void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
+    void onRequestEnd(SearchRequestContext searchRequestContext) {}
 
     boolean isEnabled(SearchRequest searchRequest) {
         return isEnabled();
@@ -69,10 +69,10 @@ public abstract class SearchRequestOperationsListener {
         }
 
         @Override
-        void onPhaseStart(SearchPhaseContext context) {
+        void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
             for (SearchRequestOperationsListener listener : listeners) {
                 try {
-                    listener.onPhaseStart(context);
+                    listener.onPhaseStart(context, searchRequestContext);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onPhaseStart listener [{}] failed", listener), e);
                 }
@@ -91,10 +91,10 @@ public abstract class SearchRequestOperationsListener {
         }
 
         @Override
-        void onPhaseFailure(SearchPhaseContext context) {
+        void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
             for (SearchRequestOperationsListener listener : listeners) {
                 try {
-                    listener.onPhaseFailure(context);
+                    listener.onPhaseFailure(context, searchRequestContext);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onPhaseFailure listener [{}] failed", listener), e);
                 }
@@ -113,10 +113,10 @@ public abstract class SearchRequestOperationsListener {
         }
 
         @Override
-        public void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        public void onRequestEnd(SearchRequestContext searchRequestContext) {
             for (SearchRequestOperationsListener listener : listeners) {
                 try {
-                    listener.onRequestEnd(context, searchRequestContext);
+                    listener.onRequestEnd(searchRequestContext);
                 } catch (Exception e) {
                     logger.warn(() -> new ParameterizedMessage("onRequestEnd listener [{}] failed", listener), e);
                 }

--- a/server/src/main/java/org/opensearch/action/search/SearchRequestStats.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequestStats.java
@@ -58,7 +58,7 @@ public final class SearchRequestStats extends SearchRequestOperationsListener {
     }
 
     @Override
-    void onPhaseStart(SearchPhaseContext context) {
+    void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
         phaseStatsMap.get(context.getCurrentPhase().getSearchPhaseName()).current.inc();
     }
 
@@ -71,7 +71,7 @@ public final class SearchRequestStats extends SearchRequestOperationsListener {
     }
 
     @Override
-    void onPhaseFailure(SearchPhaseContext context) {
+    void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
         phaseStatsMap.get(context.getCurrentPhase().getSearchPhaseName()).current.dec();
     }
 

--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -1253,7 +1253,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         clusters,
                         searchRequestContext
                     );
-                    return new SearchPhase(action.getName()) {
+                    return new SearchPhase("none") {
                         @Override
                         public void run() {
                             action.start();

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -1170,7 +1170,8 @@ public class Node implements Closeable {
                 searchModule.getFetchPhase(),
                 responseCollectorService,
                 circuitBreakerService,
-                searchModule.getIndexSearcherExecutor(threadPool)
+                searchModule.getIndexSearcherExecutor(threadPool),
+                tracer
             );
 
             final List<PersistentTasksExecutor<?>> tasksExecutors = pluginsService.filterPlugins(PersistentTaskPlugin.class)
@@ -1805,7 +1806,8 @@ public class Node implements Closeable {
         FetchPhase fetchPhase,
         ResponseCollectorService responseCollectorService,
         CircuitBreakerService circuitBreakerService,
-        Executor indexSearcherExecutor
+        Executor indexSearcherExecutor,
+        Tracer tracer
     ) {
         return new SearchService(
             clusterService,
@@ -1817,7 +1819,8 @@ public class Node implements Closeable {
             fetchPhase,
             responseCollectorService,
             circuitBreakerService,
-            indexSearcherExecutor
+            indexSearcherExecutor,
+            tracer
         );
     }
 

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -48,6 +48,7 @@ import org.opensearch.action.search.SearchExecutionStatsCollector;
 import org.opensearch.action.search.SearchPhaseController;
 import org.opensearch.action.search.SearchRequestOperationsCompositeListenerFactory;
 import org.opensearch.action.search.SearchRequestOperationsListener;
+import org.opensearch.action.search.SearchRequestCoordinatorTrace;
 import org.opensearch.action.search.SearchRequestSlowLog;
 import org.opensearch.action.search.SearchRequestStats;
 import org.opensearch.action.search.SearchTransportService;
@@ -787,6 +788,7 @@ public class Node implements Closeable {
 
             final SearchRequestStats searchRequestStats = new SearchRequestStats(clusterService.getClusterSettings());
             final SearchRequestSlowLog searchRequestSlowLog = new SearchRequestSlowLog(clusterService);
+            final SearchRequestCoordinatorTrace searchRequestCoordinatorTrace = new SearchRequestCoordinatorTrace(tracer);
 
             remoteStoreStatsTrackerFactory = new RemoteStoreStatsTrackerFactory(clusterService, settings);
             final IndicesService indicesService = new IndicesService(
@@ -1284,6 +1286,7 @@ public class Node implements Closeable {
                 b.bind(Tracer.class).toInstance(tracer);
                 b.bind(SearchRequestStats.class).toInstance(searchRequestStats);
                 b.bind(SearchRequestSlowLog.class).toInstance(searchRequestSlowLog);
+                b.bind(SearchRequestCoordinatorTrace.class).toInstance(searchRequestCoordinatorTrace);
                 b.bind(MetricsRegistry.class).toInstance(metricsRegistry);
                 b.bind(RemoteClusterStateService.class).toProvider(() -> remoteClusterStateService);
                 b.bind(PersistedStateRegistry.class).toInstance(persistedStateRegistry);

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -61,6 +61,7 @@ import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.BigArrays;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.common.util.concurrent.ConcurrentCollections;
 import org.opensearch.common.util.concurrent.ConcurrentMapLong;
 import org.opensearch.common.util.io.IOUtils;
@@ -84,6 +85,7 @@ import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryRewriteContext;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.query.Rewriteable;
+import org.opensearch.index.search.stats.ShardSearchStats;
 import org.opensearch.index.shard.IndexEventListener;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.index.shard.SearchOperationListener;
@@ -135,6 +137,9 @@ import org.opensearch.search.sort.SortBuilder;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.search.suggest.Suggest;
 import org.opensearch.search.suggest.completion.CompletionSuggestion;
+import org.opensearch.telemetry.tracing.Span;
+import org.opensearch.telemetry.tracing.SpanBuilder;
+import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.threadpool.Scheduler.Cancellable;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.threadpool.ThreadPool.Names;
@@ -158,6 +163,7 @@ import java.util.function.LongSupplier;
 import static org.opensearch.common.unit.TimeValue.timeValueHours;
 import static org.opensearch.common.unit.TimeValue.timeValueMillis;
 import static org.opensearch.common.unit.TimeValue.timeValueMinutes;
+import static org.opensearch.common.util.FeatureFlags.TELEMETRY;
 
 /**
  * The main search service
@@ -318,6 +324,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     private final AtomicInteger openPitContexts = new AtomicInteger();
     private final String sessionId = UUIDs.randomBase64UUID();
     private final Executor indexSearcherExecutor;
+    private final Tracer tracer;
 
     public SearchService(
         ClusterService clusterService,
@@ -329,7 +336,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         FetchPhase fetchPhase,
         ResponseCollectorService responseCollectorService,
         CircuitBreakerService circuitBreakerService,
-        Executor indexSearcherExecutor
+        Executor indexSearcherExecutor,
+        Tracer tracer
     ) {
         Settings settings = clusterService.getSettings();
         this.threadPool = threadPool;
@@ -346,6 +354,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             circuitBreakerService.getBreaker(CircuitBreaker.REQUEST)
         );
         this.indexSearcherExecutor = indexSearcherExecutor;
+        this.tracer = tracer;
         TimeValue keepAliveInterval = KEEPALIVE_INTERVAL_SETTING.get(settings);
         setKeepAlives(DEFAULT_KEEPALIVE_SETTING.get(settings), MAX_KEEPALIVE_SETTING.get(settings));
         setPitKeepAlives(DEFAULT_KEEPALIVE_SETTING.get(settings), MAX_PIT_KEEPALIVE_SETTING.get(settings));
@@ -606,7 +615,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             SearchContext context = createContext(readerContext, request, task, true)
         ) {
             final long afterQueryTime;
-            try (SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(context)) {
+            try (SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(context, tracer)) {
                 loadOrExecuteQueryPhase(request, context);
                 if (context.queryResult().hasSearchContext() == false && readerContext.singleSession()) {
                     freeReaderContext(readerContext.id());
@@ -637,7 +646,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     }
 
     private QueryFetchSearchResult executeFetchPhase(ReaderContext reader, SearchContext context, long afterQueryTime) {
-        try (SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(context, true, afterQueryTime)) {
+        try (SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(context, tracer, true, afterQueryTime)) {
             shortcutDocIdsToLoad(context);
             fetchPhase.execute(context);
             if (reader.singleSession()) {
@@ -666,7 +675,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             final ShardSearchRequest shardSearchRequest = readerContext.getShardSearchRequest(null);
             try (
                 SearchContext searchContext = createContext(readerContext, shardSearchRequest, task, false);
-                SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(searchContext)
+                SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(searchContext, tracer)
             ) {
                 searchContext.searcher().setAggregatedDfs(readerContext.getAggregatedDfs(null));
                 processScroll(request, readerContext, searchContext);
@@ -690,7 +699,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             readerContext.setAggregatedDfs(request.dfs());
             try (
                 SearchContext searchContext = createContext(readerContext, shardSearchRequest, task, true);
-                SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(searchContext)
+                SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(searchContext, tracer)
             ) {
                 searchContext.searcher().setAggregatedDfs(request.dfs());
                 queryPhase.execute(searchContext);
@@ -745,7 +754,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             final ShardSearchRequest shardSearchRequest = readerContext.getShardSearchRequest(null);
             try (
                 SearchContext searchContext = createContext(readerContext, shardSearchRequest, task, false);
-                SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(searchContext)
+                SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(searchContext, tracer)
             ) {
                 searchContext.assignRescoreDocIds(readerContext.getRescoreDocIds(null));
                 searchContext.searcher().setAggregatedDfs(readerContext.getAggregatedDfs(null));
@@ -776,7 +785,12 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 searchContext.searcher().setAggregatedDfs(readerContext.getAggregatedDfs(request.getAggregatedDfs()));
                 searchContext.docIdsToLoad(request.docIds(), 0, request.docIdsSize());
                 try (
-                    SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(searchContext, true, System.nanoTime())
+                    SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(
+                        searchContext,
+                        tracer,
+                        true,
+                        System.nanoTime()
+                    )
                 ) {
                     fetchPhase.execute(searchContext);
                     if (readerContext.singleSession()) {
@@ -1168,10 +1182,10 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         if (keepAlive > maxKeepAlive) {
             throw new IllegalArgumentException(
                 "Keep alive for request ("
-                    + TimeValue.timeValueMillis(keepAlive)
+                    + timeValueMillis(keepAlive)
                     + ") is too large. "
                     + "It must be less than ("
-                    + TimeValue.timeValueMillis(maxKeepAlive)
+                    + timeValueMillis(maxKeepAlive)
                     + "). "
                     + "This limit can be set by changing the ["
                     + MAX_KEEPALIVE_SETTING.getKey()
@@ -1187,10 +1201,10 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         if (keepAlive > maxPitKeepAlive) {
             throw new IllegalArgumentException(
                 "Keep alive for request ("
-                    + TimeValue.timeValueMillis(keepAlive)
+                    + timeValueMillis(keepAlive)
                     + ") is too large. "
                     + "It must be less than ("
-                    + TimeValue.timeValueMillis(maxPitKeepAlive)
+                    + timeValueMillis(maxPitKeepAlive)
                     + "). "
                     + "This limit can be set by changing the ["
                     + MAX_PIT_KEEPALIVE_SETTING.getKey()
@@ -1352,7 +1366,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                         + "] index level setting."
                 );
             }
-            for (org.opensearch.search.builder.SearchSourceBuilder.ScriptField field : source.scriptFields()) {
+            for (SearchSourceBuilder.ScriptField field : source.scriptFields()) {
                 FieldScript.Factory factory = scriptService.compile(field.script(), FieldScript.CONTEXT);
                 SearchLookup lookup = context.getQueryShardContext().lookup();
                 FieldScript.LeafFactory searchScript = factory.newFactory(field.script().getParams(), lookup);
@@ -1657,29 +1671,20 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     }
 
     /**
-     * Returns a builder for {@link InternalAggregation.ReduceContext}. This
+     * Returns a builder for {@link ReduceContext}. This
      * builder retains a reference to the provided {@link SearchSourceBuilder}.
      */
     public InternalAggregation.ReduceContextBuilder aggReduceContextBuilder(SearchSourceBuilder searchSourceBuilder) {
         return new InternalAggregation.ReduceContextBuilder() {
             @Override
-            public InternalAggregation.ReduceContext forPartialReduction() {
-                return InternalAggregation.ReduceContext.forPartialReduction(
-                    bigArrays,
-                    scriptService,
-                    () -> requestToPipelineTree(searchSourceBuilder)
-                );
+            public ReduceContext forPartialReduction() {
+                return ReduceContext.forPartialReduction(bigArrays, scriptService, () -> requestToPipelineTree(searchSourceBuilder));
             }
 
             @Override
             public ReduceContext forFinalReduction() {
                 PipelineTree pipelineTree = requestToPipelineTree(searchSourceBuilder);
-                return InternalAggregation.ReduceContext.forFinalReduction(
-                    bigArrays,
-                    scriptService,
-                    multiBucketConsumerService.create(),
-                    pipelineTree
-                );
+                return ReduceContext.forFinalReduction(bigArrays, scriptService, multiBucketConsumerService.create(), pipelineTree);
             }
         };
     }
@@ -1728,7 +1733,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
     /**
      * This helper class ensures we only execute either the success or the failure path for {@link SearchOperationListener}.
-     * This is crucial for some implementations like {@link org.opensearch.index.search.stats.ShardSearchStats}.
+     * This is crucial for some implementations like {@link ShardSearchStats}.
      */
     private static final class SearchOperationListenerExecutor implements AutoCloseable {
         private final SearchOperationListener listener;
@@ -1737,20 +1742,28 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         private final boolean fetch;
         private long afterQueryTime = -1;
         private boolean closed = false;
+        private Span querySpan = null;
+        private Span fetchSpan = null;
 
-        SearchOperationListenerExecutor(SearchContext context) {
-            this(context, false, System.nanoTime());
+        SearchOperationListenerExecutor(SearchContext context, Tracer tracer) {
+            this(context, tracer, false, System.nanoTime());
         }
 
-        SearchOperationListenerExecutor(SearchContext context, boolean fetch, long startTime) {
+        SearchOperationListenerExecutor(SearchContext context, Tracer tracer, boolean fetch, long startTime) {
             this.listener = context.indexShard().getSearchOperationListener();
             this.context = context;
             time = startTime;
             this.fetch = fetch;
             if (fetch) {
                 listener.onPreFetchPhase(context);
+                if (FeatureFlags.isEnabled(TELEMETRY)) {
+                    fetchSpan = tracer.startSpan(SpanBuilder.from("shardFetch", context));
+                }
             } else {
                 listener.onPreQueryPhase(context);
+                if (FeatureFlags.isEnabled(TELEMETRY)) {
+                    querySpan = tracer.startSpan(SpanBuilder.from("shardQuery", context));
+                }
             }
         }
 
@@ -1766,14 +1779,26 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 if (afterQueryTime != -1) {
                     if (fetch) {
                         listener.onFetchPhase(context, afterQueryTime - time);
+                        if (fetchSpan != null) {
+                            fetchSpan.endSpan();
+                        }
                     } else {
                         listener.onQueryPhase(context, afterQueryTime - time);
+                        if (querySpan != null) {
+                            querySpan.endSpan();
+                        }
                     }
                 } else {
                     if (fetch) {
                         listener.onFailedFetchPhase(context);
+                        if (fetchSpan != null) {
+                            fetchSpan.endSpan();
+                        }
                     } else {
                         listener.onFailedQueryPhase(context);
+                        if (querySpan != null) {
+                            querySpan.endSpan();
+                        }
                     }
                 }
             }

--- a/server/src/main/java/org/opensearch/telemetry/tracing/AttributeNames.java
+++ b/server/src/main/java/org/opensearch/telemetry/tracing/AttributeNames.java
@@ -94,4 +94,19 @@ public final class AttributeNames {
      * Refresh Policy
      */
     public static final String REFRESH_POLICY = "refresh_policy";
+
+    /**
+     * Search Request Source
+     */
+    public static final String SOURCE = "source";
+
+    /**
+     * Search Response Shard Stats
+     */
+    public static final String SHARDS = "shards";
+
+    /**
+     * Search Response Total Hits
+     */
+    public static final String TOTAL_HITS = "total_hits";
 }

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsCompositeListenerFactoryTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsCompositeListenerFactoryTests.java
@@ -119,13 +119,13 @@ public class SearchRequestOperationsCompositeListenerFactoryTests extends OpenSe
     public SearchRequestOperationsListener createTestSearchRequestOperationsListener() {
         return new SearchRequestOperationsListener() {
             @Override
-            void onPhaseStart(SearchPhaseContext context) {}
+            void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
             @Override
             void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
 
             @Override
-            void onPhaseFailure(SearchPhaseContext context) {}
+            void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
         };
     }
 }

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerSupport.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerSupport.java
@@ -17,7 +17,7 @@ import java.util.List;
  */
 public interface SearchRequestOperationsListenerSupport {
     default void onPhaseStart(SearchRequestOperationsListener listener, SearchPhaseContext context) {
-        listener.onPhaseStart(context);
+        listener.onPhaseStart(context, new SearchRequestContext());
     }
 
     default void onPhaseEnd(SearchRequestOperationsListener listener, SearchPhaseContext context) {

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestOperationsListenerTests.java
@@ -29,7 +29,7 @@ public class SearchRequestOperationsListenerTests extends OpenSearchTestCase {
         SearchRequestOperationsListener testListener = new SearchRequestOperationsListener() {
 
             @Override
-            public void onPhaseStart(SearchPhaseContext context) {
+            public void onPhaseStart(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
                 searchPhaseMap.get(context.getCurrentPhase().getSearchPhaseName()).current.inc();
             }
 
@@ -40,7 +40,7 @@ public class SearchRequestOperationsListenerTests extends OpenSearchTestCase {
             }
 
             @Override
-            public void onPhaseFailure(SearchPhaseContext context) {
+            public void onPhaseFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
                 searchPhaseMap.get(context.getCurrentPhase().getSearchPhaseName()).current.dec();
             }
         };
@@ -62,7 +62,7 @@ public class SearchRequestOperationsListenerTests extends OpenSearchTestCase {
         for (SearchPhaseName searchPhaseName : SearchPhaseName.values()) {
             when(ctx.getCurrentPhase()).thenReturn(searchPhase);
             when(searchPhase.getSearchPhaseName()).thenReturn(searchPhaseName);
-            compositeListener.onPhaseStart(ctx);
+            compositeListener.onPhaseStart(ctx, new SearchRequestContext());
             assertEquals(totalListeners, searchPhaseMap.get(searchPhaseName).current.count());
         }
     }

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestSlowLogTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestSlowLogTests.java
@@ -114,7 +114,6 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
     public void testOnRequestEnd() throws InterruptedException {
         final Logger logger = mock(Logger.class);
         final SearchRequestContext searchRequestContext = mock(SearchRequestContext.class);
-        final SearchPhaseContext searchPhaseContext = mock(SearchPhaseContext.class);
         final SearchRequest searchRequest = mock(SearchRequest.class);
         final SearchTask searchTask = mock(SearchTask.class);
 
@@ -132,11 +131,11 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
             new SearchRequestOperationsListener.CompositeListener(searchListenersList, logger)
         );
         when(searchRequestContext.getAbsoluteStartNanos()).thenReturn(System.nanoTime() - 1L);
-        when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
-        when(searchPhaseContext.getTask()).thenReturn(searchTask);
+        when(searchRequestContext.getSearchRequest()).thenReturn(searchRequest);
+        when(searchRequestContext.getSearchTask()).thenReturn(searchTask);
         when(searchRequest.searchType()).thenReturn(SearchType.QUERY_THEN_FETCH);
 
-        searchRequestContext.getSearchRequestOperationsListener().onRequestEnd(searchPhaseContext, searchRequestContext);
+        searchRequestContext.getSearchRequestOperationsListener().onRequestEnd(searchRequestContext);
 
         verify(logger, never()).warn(any(SearchRequestSlowLog.SearchRequestSlowLogMessage.class));
         verify(logger, times(1)).info(any(SearchRequestSlowLog.SearchRequestSlowLogMessage.class));
@@ -146,7 +145,6 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
 
     public void testConcurrentOnRequestEnd() throws InterruptedException {
         final Logger logger = mock(Logger.class);
-        final SearchPhaseContext searchPhaseContext = mock(SearchPhaseContext.class);
         final SearchRequest searchRequest = mock(SearchRequest.class);
         final SearchTask searchTask = mock(SearchTask.class);
 
@@ -161,8 +159,6 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
         SearchRequestSlowLog searchRequestSlowLog = new SearchRequestSlowLog(clusterService, logger);
         final List<SearchRequestOperationsListener> searchListenersList = new ArrayList<>(List.of(searchRequestSlowLog));
 
-        when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
-        when(searchPhaseContext.getTask()).thenReturn(searchTask);
         when(searchRequest.searchType()).thenReturn(SearchType.QUERY_THEN_FETCH);
 
         int numRequests = 50;
@@ -179,6 +175,7 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
                 new SearchRequestOperationsListener.CompositeListener(searchListenersList, logger),
                 searchRequest
             );
+            searchRequestContext.setSearchTask(searchTask);
             searchRequestContext.setAbsoluteStartNanos((i < numRequestsLogged) ? 0 : System.nanoTime());
             searchRequestContexts.add(searchRequestContext);
         }
@@ -188,7 +185,7 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
             threads[i] = new Thread(() -> {
                 phaser.arriveAndAwaitAdvance();
                 SearchRequestContext thisContext = searchRequestContexts.get(finalI);
-                thisContext.getSearchRequestOperationsListener().onRequestEnd(searchPhaseContext, thisContext);
+                thisContext.getSearchRequestOperationsListener().onRequestEnd(thisContext);
                 countDownLatch.countDown();
             });
             threads[i].start();
@@ -211,7 +208,6 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
             searchRequest
         );
         SearchRequestSlowLog.SearchRequestSlowLogMessage p = new SearchRequestSlowLog.SearchRequestSlowLogMessage(
-            searchPhaseContext,
             10,
             searchRequestContext
         );
@@ -223,7 +219,7 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
         assertThat(p.getValueFor("search_type"), equalTo("QUERY_THEN_FETCH"));
         assertThat(p.getValueFor("shards"), equalTo(""));
         assertThat(p.getValueFor("source"), equalTo("{\\\"query\\\":{\\\"match_all\\\":{\\\"boost\\\":1.0}}}"));
-        assertThat(p.getValueFor("id"), equalTo(null));
+        assertThat(p.getValueFor("id"), equalTo(""));
     }
 
     public void testSearchRequestSlowLogHasJsonFields_NotEmptySearchRequestContext() throws IOException {
@@ -239,11 +235,7 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
         searchRequestContext.updatePhaseTookMap(SearchPhaseName.EXPAND.getName(), 5L);
         searchRequestContext.setTotalHits(new TotalHits(3L, TotalHits.Relation.EQUAL_TO));
         searchRequestContext.setShardStats(10, 8, 1, 1);
-        SearchRequestSlowLog.SearchRequestSlowLogMessage p = new SearchRequestSlowLog.SearchRequestSlowLogMessage(
-            searchPhaseContext,
-            10,
-            searchRequestContext
-        );
+        SearchRequestSlowLog.SearchRequestSlowLogMessage p = new SearchRequestSlowLog.SearchRequestSlowLogMessage(10, searchRequestContext);
 
         assertThat(p.getValueFor("took"), equalTo("10nanos"));
         assertThat(p.getValueFor("took_millis"), equalTo("0"));
@@ -252,7 +244,7 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
         assertThat(p.getValueFor("search_type"), equalTo("QUERY_THEN_FETCH"));
         assertThat(p.getValueFor("shards"), equalTo("{total:10, successful:8, skipped:1, failed:1}"));
         assertThat(p.getValueFor("source"), equalTo("{\\\"query\\\":{\\\"match_all\\\":{\\\"boost\\\":1.0}}}"));
-        assertThat(p.getValueFor("id"), equalTo(null));
+        assertThat(p.getValueFor("id"), equalTo(""));
     }
 
     public void testSearchRequestSlowLogHasJsonFields_PartialContext() throws IOException {
@@ -269,7 +261,6 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
         searchRequestContext.setTotalHits(new TotalHits(3L, TotalHits.Relation.EQUAL_TO));
         searchRequestContext.setShardStats(5, 3, 1, 1);
         SearchRequestSlowLog.SearchRequestSlowLogMessage p = new SearchRequestSlowLog.SearchRequestSlowLogMessage(
-            searchPhaseContext,
             10000000000L,
             searchRequestContext
         );
@@ -281,7 +272,7 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
         assertThat(p.getValueFor("search_type"), equalTo("QUERY_THEN_FETCH"));
         assertThat(p.getValueFor("shards"), equalTo("{total:5, successful:3, skipped:1, failed:1}"));
         assertThat(p.getValueFor("source"), equalTo("{\\\"query\\\":{\\\"match_all\\\":{\\\"boost\\\":1.0}}}"));
-        assertThat(p.getValueFor("id"), equalTo(null));
+        assertThat(p.getValueFor("id"), equalTo(""));
     }
 
     public void testSearchRequestSlowLogSearchContextPrinterToLog() throws IOException {
@@ -298,7 +289,6 @@ public class SearchRequestSlowLogTests extends OpenSearchTestCase {
         searchRequestContext.setTotalHits(new TotalHits(3L, TotalHits.Relation.EQUAL_TO));
         searchRequestContext.setShardStats(10, 8, 1, 1);
         SearchRequestSlowLog.SearchRequestSlowLogMessage p = new SearchRequestSlowLog.SearchRequestSlowLogMessage(
-            searchPhaseContext,
             100000,
             searchRequestContext
         );

--- a/server/src/test/java/org/opensearch/action/search/SearchRequestStatsTests.java
+++ b/server/src/test/java/org/opensearch/action/search/SearchRequestStatsTests.java
@@ -34,9 +34,9 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
 
         for (SearchPhaseName searchPhaseName : SearchPhaseName.values()) {
             when(mockSearchPhase.getSearchPhaseName()).thenReturn(searchPhaseName);
-            testRequestStats.onPhaseStart(ctx);
+            testRequestStats.onPhaseStart(ctx, new SearchRequestContext());
             assertEquals(1, testRequestStats.getPhaseCurrent(searchPhaseName));
-            testRequestStats.onPhaseFailure(ctx);
+            testRequestStats.onPhaseFailure(ctx, new SearchRequestContext());
             assertEquals(0, testRequestStats.getPhaseCurrent(searchPhaseName));
         }
     }
@@ -52,7 +52,7 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
         for (SearchPhaseName searchPhaseName : SearchPhaseName.values()) {
             when(mockSearchPhase.getSearchPhaseName()).thenReturn(searchPhaseName);
             long tookTimeInMillis = randomIntBetween(1, 10);
-            testRequestStats.onPhaseStart(ctx);
+            testRequestStats.onPhaseStart(ctx, new SearchRequestContext());
             long startTime = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(tookTimeInMillis);
             when(mockSearchPhase.getStartTimeInNanos()).thenReturn(startTime);
             assertEquals(1, testRequestStats.getPhaseCurrent(searchPhaseName));
@@ -84,7 +84,7 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
             for (int i = 0; i < numTasks; i++) {
                 threads[i] = new Thread(() -> {
                     phaser.arriveAndAwaitAdvance();
-                    testRequestStats.onPhaseStart(ctx);
+                    testRequestStats.onPhaseStart(ctx, new SearchRequestContext());
                     countDownLatch.countDown();
                 });
                 threads[i].start();
@@ -155,8 +155,8 @@ public class SearchRequestStatsTests extends OpenSearchTestCase {
             for (int i = 0; i < numTasks; i++) {
                 threads[i] = new Thread(() -> {
                     phaser.arriveAndAwaitAdvance();
-                    testRequestStats.onPhaseStart(ctx);
-                    testRequestStats.onPhaseFailure(ctx);
+                    testRequestStats.onPhaseStart(ctx, new SearchRequestContext());
+                    testRequestStats.onPhaseFailure(ctx, new SearchRequestContext());
                     countDownLatch.countDown();
                 });
                 threads[i].start();

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -2313,7 +2313,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                             client
                         ),
                         NoopMetricsRegistry.INSTANCE,
-                        searchRequestOperationsCompositeListenerFactory
+                        searchRequestOperationsCompositeListenerFactory,
+                        NoopTracer.INSTANCE
                     )
                 );
                 actions.put(

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -2279,7 +2279,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     new FetchPhase(Collections.emptyList()),
                     responseCollectorService,
                     new NoneCircuitBreakerService(),
-                    null
+                    null,
+                    NoopTracer.INSTANCE
                 );
                 SearchPhaseController searchPhaseController = new SearchPhaseController(
                     writableRegistry(),

--- a/test/framework/src/main/java/org/opensearch/node/MockNode.java
+++ b/test/framework/src/main/java/org/opensearch/node/MockNode.java
@@ -155,7 +155,8 @@ public class MockNode extends Node {
         FetchPhase fetchPhase,
         ResponseCollectorService responseCollectorService,
         CircuitBreakerService circuitBreakerService,
-        Executor indexSearcherExecutor
+        Executor indexSearcherExecutor,
+        Tracer tracer
     ) {
         if (getPluginsService().filterPlugins(MockSearchService.TestPlugin.class).isEmpty()) {
             return super.newSearchService(
@@ -168,7 +169,8 @@ public class MockNode extends Node {
                 fetchPhase,
                 responseCollectorService,
                 circuitBreakerService,
-                indexSearcherExecutor
+                indexSearcherExecutor,
+                tracer
             );
         }
         return new MockSearchService(
@@ -180,7 +182,8 @@ public class MockNode extends Node {
             queryPhase,
             fetchPhase,
             circuitBreakerService,
-            indexSearcherExecutor
+            indexSearcherExecutor,
+            tracer
         );
     }
 

--- a/test/framework/src/main/java/org/opensearch/search/MockSearchService.java
+++ b/test/framework/src/main/java/org/opensearch/search/MockSearchService.java
@@ -42,6 +42,7 @@ import org.opensearch.script.ScriptService;
 import org.opensearch.search.fetch.FetchPhase;
 import org.opensearch.search.internal.ReaderContext;
 import org.opensearch.search.query.QueryPhase;
+import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.threadpool.ThreadPool;
 
 import java.util.HashMap;
@@ -96,7 +97,8 @@ public class MockSearchService extends SearchService {
         QueryPhase queryPhase,
         FetchPhase fetchPhase,
         CircuitBreakerService circuitBreakerService,
-        Executor indexSearcherExecutor
+        Executor indexSearcherExecutor,
+        Tracer tracer
     ) {
         super(
             clusterService,
@@ -108,7 +110,8 @@ public class MockSearchService extends SearchService {
             fetchPhase,
             null,
             circuitBreakerService,
-            indexSearcherExecutor
+            indexSearcherExecutor,
+            tracer
         );
     }
 


### PR DESCRIPTION
### Description

Tracing instrumentation at deep search path

Added spans at: 
1. Coordinator node
2. Coordinator node search phases
3. Shard query and fetch phases

### Testing
```
% curl -X PUT "localhost:9200/test2?pretty" -H 'Content-Type: application/json' -d'                                                                    
{                                                  
  "settings": {
    "number_of_shards": 10
  }
}'

% curl -X POST "localhost:9200/_bulk?pretty" -H 'Content-Type: application/json' -d'
{ "index" : { "_index" : "test2", "_id" : "1" } }
{ "field1" : "value1" }
{ "index" : { "_index" : "test2", "_id" : "2" } }
{ "field2" : "value2" }
'

% curl -XGET 'localhost:9200/_search?pretty&phase_took' -H 'X-Opaque-Id: my-id' -H 'Content-Type: application/json' -d'{
 "query": { "match_all": {} }
}'

```
![Screenshot 2023-12-13 at 9 57 15 AM](https://github.com/dzane17/OpenSearch/assets/38449481/f542d1ea-d279-4945-8015-6a621411d4d7)

### Sample Span Details
##### 1. Coordinator node
![Screenshot 2023-12-13 at 2 10 42 PM](https://github.com/dzane17/OpenSearch/assets/38449481/949ccb76-0b51-4766-934c-eb268561a422)

```
{
   "traceId":"e522537a055adc6fc59667b58347942c",
   "spanId":"5b42e305497d91f8",
   "parentSpanId":"dab8a74cc0bb10c1",
   "name":"coordinatorRequest",
   "kind":2,
   "startTimeUnixNano":"1702333271222480100",
   "endTimeUnixNano":"1702333271229240384",
   "attributes":[
      {
         "key":"thread.name",
         "value":{
            "stringValue":"opensearch[88665a158598.ant.amazon.com][transport_worker][T#8]"
         }
      },
      {
         "key":"total_hits",
         "value":{
            "stringValue":"4 hits"
         }
      },
      {
         "key":"shards",
         "value":{
            "stringValue":"{total:2, successful:2, skipped:0, failed:0}"
         }
      }
   ],
   "status":{
      
   }
}
```

##### 2. Coordinator node phase
![Screenshot 2023-12-13 at 2 11 40 PM](https://github.com/dzane17/OpenSearch/assets/38449481/e6ff6ae2-945d-4fd7-8712-88032ebb97e7)

```
{
   "traceId":"e522537a055adc6fc59667b58347942c",
   "spanId":"c8ef2d7ad2584a6c",
   "parentSpanId":"5b42e305497d91f8",
   "name":"coordinatorQuery",
   "kind":2,
   "startTimeUnixNano":"1702333271223157629",
   "endTimeUnixNano":"1702333271225489595",
   "attributes":[
      {
         "key":"thread.name",
         "value":{
            "stringValue":"opensearch[88665a158598.ant.amazon.com][transport_worker][T#8]"
         }
      }
   ],
   "status":{
      
   }
}
```

##### 3. Shard phase
![Screenshot 2023-12-13 at 2 14 18 PM](https://github.com/dzane17/OpenSearch/assets/38449481/991e154c-94c0-46f7-910e-548b0927f1a8)

````
{
   "traceId":"e522537a055adc6fc59667b58347942c",
   "spanId":"637c47eaa1d956da",
   "parentSpanId":"c8ef2d7ad2584a6c",
   "name":"shardQuery",
   "kind":2,
   "startTimeUnixNano":"1702333271224104730",
   "endTimeUnixNano":"1702333271224698102",
   "attributes":[
      {
         "key":"thread.name",
         "value":{
            "stringValue":"opensearch[88665a158598.ant.amazon.com][search][T#3]"
         }
      },
      {
         "key":"index",
         "value":{
            "stringValue":"test1"
         }
      },
      {
         "key":"shard_id",
         "value":{
            "intValue":"0"
         }
      }
   ],
   "status":{
      
   }
}
````

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [x] Commits are signed per the DCO using --signoff
- [x] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
